### PR TITLE
ci: auto-open bump PRs for @letta-ai dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Auto-open bump PRs when @letta-ai dependencies (letta-agent-sdk) publish new
+# versions. Scoped to @letta-ai/* so unrelated dependency churn stays out.
+# versioning-strategy: increase makes in-range releases (e.g. ^0.2.6 -> 0.2.7)
+# still produce a PR that moves the manifest + lockfile forward.
+version: 2
+updates:
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@letta-ai/*"
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "chore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 # Auto-open bump PRs when @letta-ai dependencies (letta-agent-sdk) publish new
-# versions. Scoped to @letta-ai/* so unrelated dependency churn stays out.
+# versions, mirroring letta-agent-sdk's config for letta-code bumps. The bun
+# ecosystem keeps the committed bun.lock in sync with the manifest.
 # versioning-strategy: increase makes in-range releases (e.g. ^0.2.6 -> 0.2.7)
 # still produce a PR that moves the manifest + lockfile forward.
 version: 2
@@ -11,5 +12,7 @@ updates:
     allow:
       - dependency-name: "@letta-ai/*"
     versioning-strategy: "increase"
+    labels:
+      - "dependencies"
     commit-message:
-      prefix: "chore"
+      prefix: "chore(deps):"


### PR DESCRIPTION
## Summary
- Adds a Dependabot config that opens a bump PR whenever `@letta-ai/letta-agent-sdk` publishes a new version, mirroring the config letta-agent-sdk already has for `@letta-ai/letta-code` bumps (same daily schedule, `@letta-ai/*` scope, `versioning-strategy: increase`, `dependencies` label, `chore(deps):` prefix).
- One deliberate difference: `package-ecosystem: bun` instead of `npm`, because this repo **commits** `bun.lock` — the npm ecosystem would bump only package.json and leave the lockfile stale, breaking our `bun install --frozen-lockfile` CI. The bun ecosystem updates manifest + `bun.lock` together. (letta-agent-sdk gitignores its lockfile, so npm-ecosystem manifest-only bumps are correct there.)
- `versioning-strategy: increase` makes in-range releases (e.g. `^0.2.6` → 0.2.7) still produce a PR that moves the manifest + lockfile forward; out-of-range releases (0.3.x) get PRs as usual.
- CI (pack + consumer-install smoke test) gates each bump PR; merging stays manual, and publishing the bumped adapter is still an explicit release dispatch.

👾 Generated with [Letta Code](https://letta.com)