### PR TITLE
Fix hang when session/cancel lands before the run's first token

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -464,16 +464,24 @@ export class LettaAcpAgent {
       if (message.type === "result") {
         return { kind: "result", result: message };
       }
-      if (message.type === "loop_status" && mode === "recovery") {
-        if (message.status === "WAITING_ON_INPUT") {
-          idleStatusCount += 1;
-          // The first idle status can be stale (queued before the resume);
-          // trust it once we've seen real activity or it repeats.
-          if (sawActivity || idleStatusCount >= 2 || state.cancelled) {
-            return { kind: "idle" };
-          }
+      if (message.type === "loop_status") {
+        // An abort that lands before the run produces output never gets a
+        // terminal result from the SDK — the return to WAITING_ON_INPUT is
+        // the only end-of-turn signal, in "turn" mode too.
+        if (message.status === "WAITING_ON_INPUT" && state.cancelled) {
+          return { kind: "idle" };
         }
-        continue;
+        if (mode === "recovery") {
+          if (message.status === "WAITING_ON_INPUT") {
+            idleStatusCount += 1;
+            // The first idle status can be stale (queued before the resume);
+            // trust it once we've seen real activity or it repeats.
+            if (sawActivity || idleStatusCount >= 2) {
+              return { kind: "idle" };
+            }
+          }
+          continue;
+        }
       }
       const forwarded = await this.forwardMessage(
         sessionId,


### PR DESCRIPTION
## Problem

If an ACP `session/cancel` arrives before the model produces its first token, the prompt turn hangs forever: the adapter calls `session.abort()`, the server aborts the run, but the SDK only synthesizes an `interrupted` result when the turn has produced *turn evidence* (assistant/reasoning deltas). With no evidence, the `WAITING_ON_INPUT` loop status that follows the abort is ignored, no terminal result is ever emitted, and `pumpStream` blocks on the stream indefinitely — the ACP client never gets a response for its `session/prompt` request.

Reproduced deterministically against a self-hosted app server (`LETTA_ACP_BACKEND=remote`) with:

```bash
ACP_TEST_CANCEL_AFTER=1500 bun test-client.ts "Count from 1 to 2000, one number per line."
```

Cancels that landed mid-stream (after the first token) already worked, since the SDK's abort handling kicks in once there is turn evidence.

## Fix

The raw `loop_status` messages still reach the adapter's stream even when the SDK skips result synthesis. So `pumpStream` now treats `WAITING_ON_INPUT` on a cancelled turn as the end-of-turn signal in **both** pump modes (previously loop statuses were only interpreted in `recovery` mode). `prompt()` already checks `state.cancelled` after the pump returns and maps the outcome to `stopReason: cancelled`.

If the cancel races a stale queued `WAITING_ON_INPUT`, the outcome is still correct: the turn was cancelled and `session.abort()` has already been dispatched server-side.

## Verification

All runs against a self-hosted app server (`letta server --backend local --listen ws://127.0.0.1:4500`) with `LETTA_ACP_BACKEND=remote`:

- Cancel at 1.5s (pre-first-token): previously hung forever, now returns `stopReason: cancelled` promptly
- Cancel at 2.5s (mid-stream): still returns `stopReason: cancelled`
- Smoke test, Bash tool call, Write + permission flow (incl. `approval_conflict` recovery), permission rejection, and `session/load` history replay: all still pass
- `bunx tsc --noEmit` clean