### PR TITLE
feat(config): add cloud-oauth backend for keyless Letta Cloud access

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,20 @@ to `bun`, e.g. `~/.bun/bin/bun`, since Zed may not have it on its PATH.)
 Then open the Agent Panel, click the **+** button (or the dropdown arrow next
 to it), and choose **Letta** from the external agents list to start a thread.
 
+To drive a **Letta Cloud** agent from Zed without putting an API key in
+`settings.json`, run `letta login` once and use the
+[`cloud-oauth`](#letta-cloud-via-oauth-cloud-oauth) backend:
+
+```json
+"env": {
+  "LETTA_ACP_BACKEND": "cloud-oauth",
+  "LETTA_AGENT_ID": "agent-..."
+}
+```
+
 ## Configuration
 
-The adapter reaches Letta through one of three backends, selected with
+The adapter reaches Letta through one of four backends, selected with
 `LETTA_ACP_BACKEND` ([self-hosting docs](https://docs.letta.com/self-hosting)).
 Each subsection below shows the full `env` block for that backend.
 
@@ -78,6 +89,31 @@ sandbox. Get an API key at
   "LETTA_AGENT_ID": "agent-..."
 }
 ```
+
+### Letta Cloud via OAuth (`cloud-oauth`)
+
+Same cloud agents as `cloud`, but authenticated with your existing
+`letta login` session instead of an API key — so no long-lived secret has to
+be pasted into your editor's settings file.
+
+```json
+"env": {
+  "LETTA_ACP_BACKEND": "cloud-oauth",
+  "LETTA_AGENT_ID": "agent-..."
+}
+```
+
+Run `letta login` once, then start a thread. Credentials are resolved by the
+letta-code harness exactly as the CLI does it: OAuth tokens from your OS
+keychain (macOS Keychain, Windows Credential Manager, libsecret), refreshed
+automatically as they expire, falling back to `LETTA_API_KEY` if one is set.
+
+Mechanically this is the `local` backend with the harness pointed at Letta
+Cloud (`harnessBackend: "api"`): the SDK spawns a loopback app-server on your
+machine, the agent and its memory live in Cloud (real `agent-*` ids, cloud-side
+models), and — unlike `cloud` — built-in tools such as `Read` and `Bash`
+execute against **your** filesystem rather than a cloud sandbox. For editor use
+that's usually what you want.
 
 ### Local runtime (`local`, default)
 
@@ -126,7 +162,7 @@ non-loopback deployments enable auth
 
 Note on tool execution: with `remote` and `cloud`, built-in tools (Read, Bash,
 …) run where the harness runs — the server/sandbox filesystem, not your
-machine. The editor fs tools (`read_editor_buffer`, `write_via_editor`) always
+machine. With `local` and `cloud-oauth` they run on your machine. The editor fs tools (`read_editor_buffer`, `write_via_editor`) always
 operate on the editor's files regardless of backend, since they execute in the
 adapter and delegate to the ACP client.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import type {
 } from "@letta-ai/letta-agent-sdk";
 
 export interface LettaAcpConfig {
-  /** Letta backend client options (local | remote | cloud). */
+  /** Letta backend client options (local | remote | cloud | cloud-oauth). */
   clientOptions: LettaCodeClientOptions;
   /** Reuse an existing agent instead of creating one on first session. */
   agentId?: string;
@@ -19,6 +19,8 @@ const PERMISSION_MODES: PermissionMode[] = [
   "acceptEdits",
   "unrestricted",
 ];
+
+const BACKENDS = ["local", "remote", "cloud", "cloud-oauth"] as const;
 
 export function configFromEnv(
   env: Record<string, string | undefined> = process.env,
@@ -40,14 +42,29 @@ export function configFromEnv(
     case "cloud": {
       const apiKey = env.LETTA_API_KEY;
       if (!apiKey) {
-        throw new Error("LETTA_ACP_BACKEND=cloud requires LETTA_API_KEY");
+        throw new Error(
+          "LETTA_ACP_BACKEND=cloud requires LETTA_API_KEY. " +
+            'To use your existing `letta login` session instead, set LETTA_ACP_BACKEND="cloud-oauth".',
+        );
       }
       clientOptions = { backend: "cloud", apiKey };
       break;
     }
+    case "cloud-oauth":
+      // Cloud agents authenticated through the letta-code harness rather than
+      // an explicit API key: the SDK spawns a local app-server pointed at
+      // Letta Cloud, and that harness resolves credentials the same way the
+      // CLI does (OS keychain tokens from `letta login`, with automatic
+      // refresh, falling back to LETTA_API_KEY when present). Tools still
+      // execute on this machine.
+      clientOptions = {
+        backend: "local",
+        appServer: { harnessBackend: "api" },
+      };
+      break;
     default:
       throw new Error(
-        `Unknown LETTA_ACP_BACKEND "${backend}" (expected local | remote | cloud)`,
+        `Unknown LETTA_ACP_BACKEND "${backend}" (expected ${BACKENDS.join(" | ")})`,
       );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,10 @@
  * backed by a Letta agent via @letta-ai/letta-agent-sdk.
  *
  * Environment:
- *   LETTA_ACP_BACKEND          local (default) | remote | cloud
+ *   LETTA_ACP_BACKEND          local (default) | remote | cloud | cloud-oauth
  *   LETTA_APP_SERVER_URL       remote backend URL (default ws://127.0.0.1:4500)
  *   LETTA_APP_SERVER_TOKEN     remote backend auth token
- *   LETTA_API_KEY              cloud backend API key
+ *   LETTA_API_KEY              cloud backend API key (not needed for cloud-oauth)
  *   LETTA_AGENT_ID             reuse an existing agent (recommended)
  *   LETTA_ACP_MODEL            model override for sessions
  *   LETTA_ACP_PERMISSION_MODE  standard (default) | acceptEdits | unrestricted


### PR DESCRIPTION
## Summary

The `cloud` backend requires `LETTA_API_KEY`. For editor clients that means pasting a long-lived secret into a plaintext settings file (e.g. Zed's `settings.json`) even when the user has already run `letta login` — so this adds a `cloud-oauth` backend that reuses that existing session instead.

```json
"env": {
  "LETTA_ACP_BACKEND": "cloud-oauth",
  "LETTA_AGENT_ID": "agent-..."
}
```

Credentials resolve through the letta-code harness exactly as the CLI does it: OAuth tokens from the OS keychain, refreshed automatically on expiry, falling back to `LETTA_API_KEY` when present. No new auth code — it reuses the harness' existing flow rather than reimplementing token handling in the adapter.

### Implementation

`cloud-oauth` maps to the `local` backend with `appServer.harnessBackend: "api"`. The agent and its memory live in Cloud (real `agent-*` ids, cloud-side models); the difference from `cloud` is that the harness runs locally, so built-in tools (`Read`, `Bash`, …) execute against the user's filesystem instead of a cloud sandbox — generally what you want for an editor integration.

Also updates the `cloud` missing-key error to point at the new option, and documents the tool-execution distinction in the backends table note.

### Alternative considered

Reading keychain tokens directly in the adapter (via letta-code's `getSecureTokens`) was rejected: it would couple the adapter to letta-code internals and duplicate refresh logic that the harness already owns.

## Test plan

- [x] `bun run check` (typecheck + build) passes
- [x] `cloud` without a key errors with the new message pointing at `cloud-oauth`
- [x] Unknown backend value lists all four options
- [x] `cloud-oauth` authenticates with **`LETTA_API_KEY` stripped from the environment** (`env -u LETTA_API_KEY`) — full ACP round trip, `stopReason: end_turn`
- [x] Confirmed it resolves a **Cloud** agent (`agent-*`) and Cloud conversation (`conv-<uuid>`), not local (`agent-local-*` / `local-conv-N`) — this id shape is what proves the Cloud path actually ran
- [x] Replayed the spawn the way an editor does it: real `agent_servers` entry from `~/.config/zed/settings.json`, absolute command path, and a **dock-launched-app environment** (minimal `PATH`, no shell exports, so no `LETTA_API_KEY` could leak in). Keychain auth succeeded with no shell context.
- [x] Verified tool execution is **local, not sandboxed**: `hostname` returned this machine and `ls` listed the real home-directory contents, while the agent id remained a Cloud one
- [x] Confirmed working end-to-end through the **Zed Agent Panel** UI by a human tester, using `cloud-oauth` with no API key in `settings.json`

👾 Generated with [Letta Code](https://letta.com)
