### PR TITLE
fix: bound editor filesystem requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
     "build": "tsc -p tsconfig.build.json",
     "prepare": "npm run build",
     "typecheck": "tsc --noEmit",
+    "test": "bun test",
     "test:client": "bun test-client.ts",
-    "check": "bun run typecheck && bun run build"
+    "check": "bun run test && bun run typecheck && bun run build"
   },
   "devDependencies": {
     "@types/bun": "^1.3.0",

--- a/src/editor-tools.ts
+++ b/src/editor-tools.ts
@@ -14,6 +14,8 @@ interface EditorToolContext {
   getPromptContext: () => AgentContext | null;
 }
 
+const DEFAULT_EDITOR_REQUEST_TIMEOUT_MS = 30_000;
+
 /**
  * External tools that delegate file access to the ACP client (the editor).
  *
@@ -26,6 +28,7 @@ interface EditorToolContext {
 export function createEditorTools(
   caps: EditorFsCapabilities,
   context: EditorToolContext,
+  requestTimeoutMs = DEFAULT_EDITOR_REQUEST_TIMEOUT_MS,
 ): AnyAgentTool[] {
   const tools: AnyAgentTool[] = [];
   if (caps.readTextFile) {
@@ -58,12 +61,21 @@ export function createEditorTools(
       execute: async (_toolCallId, args) => {
         const { path, line, limit } = readFsArgs(args, { allowRange: true });
         const cx = requireContext(context);
-        const response = await cx.request(methods.client.fs.readTextFile, {
-          sessionId: context.getSessionId(),
-          path,
-          ...(line !== undefined ? { line } : {}),
-          ...(limit !== undefined ? { limit } : {}),
-        });
+        const response = await withEditorRequestTimeout(
+          (signal) =>
+            cx.request(
+              methods.client.fs.readTextFile,
+              {
+                sessionId: context.getSessionId(),
+                path,
+                ...(line !== undefined ? { line } : {}),
+                ...(limit !== undefined ? { limit } : {}),
+              },
+              { cancellationSignal: signal },
+            ),
+          `read ${path}`,
+          requestTimeoutMs,
+        );
         return { content: [{ type: "text", text: response.content }] };
       },
     });
@@ -100,11 +112,20 @@ export function createEditorTools(
           throw new Error("content must be a string");
         }
         const cx = requireContext(context);
-        await cx.request(methods.client.fs.writeTextFile, {
-          sessionId: context.getSessionId(),
-          path,
-          content,
-        });
+        await withEditorRequestTimeout(
+          (signal) =>
+            cx.request(
+              methods.client.fs.writeTextFile,
+              {
+                sessionId: context.getSessionId(),
+                path,
+                content,
+              },
+              { cancellationSignal: signal },
+            ),
+          `write ${path}`,
+          requestTimeoutMs,
+        );
         return {
           content: [{ type: "text", text: `Wrote ${path} via the editor.` }],
         };
@@ -112,6 +133,32 @@ export function createEditorTools(
     });
   }
   return tools;
+}
+
+async function withEditorRequestTimeout<T>(
+  request: (signal: AbortSignal) => Promise<T>,
+  description: string,
+  timeoutMs: number,
+): Promise<T> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const error = new Error(
+        `Editor request timed out after ${timeoutMs}ms while trying to ${description}`,
+      );
+      reject(error);
+      // ACP cancellation is cooperative, so the local timeout above is what
+      // guarantees the tool returns even when the client is completely stuck.
+      controller.abort(error);
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([request(controller.signal), timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 function requireContext(context: EditorToolContext): AgentContext {

--- a/test/editor-tools.test.ts
+++ b/test/editor-tools.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentContext } from "@agentclientprotocol/sdk";
+import type { AnyAgentTool } from "@letta-ai/letta-agent-sdk";
+import { createEditorTools } from "../src/editor-tools.js";
+
+type RequestOptions = { cancellationSignal?: AbortSignal };
+type FakeRequest = (
+  method: string,
+  params: unknown,
+  options?: RequestOptions,
+) => Promise<unknown>;
+
+function editorTool(name: string, request: FakeRequest): AnyAgentTool {
+  const context = {
+    getSessionId: () => "conv-test",
+    getPromptContext: () => ({ request }) as unknown as AgentContext,
+  };
+  const tool = createEditorTools(
+    { readTextFile: true, writeTextFile: true },
+    context,
+    10,
+  ).find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`Missing editor tool ${name}`);
+  return tool;
+}
+
+describe("editor filesystem request timeouts", () => {
+  test("read_editor_buffer stops waiting when the editor never responds", async () => {
+    let signal: AbortSignal | undefined;
+    const tool = editorTool("read_editor_buffer", (_method, _params, options) => {
+      signal = options?.cancellationSignal;
+      return new Promise(() => {});
+    });
+
+    await expect(
+      tool.execute("call-read", { path: "/tmp/input.ts" }),
+    ).rejects.toThrow(
+      "Editor request timed out after 10ms while trying to read /tmp/input.ts",
+    );
+    expect(signal?.aborted).toBe(true);
+  });
+
+  test("write_via_editor stops waiting when the editor never responds", async () => {
+    let signal: AbortSignal | undefined;
+    const tool = editorTool("write_via_editor", (_method, _params, options) => {
+      signal = options?.cancellationSignal;
+      return new Promise(() => {});
+    });
+
+    await expect(
+      tool.execute("call-write", {
+        path: "/tmp/output.ts",
+        content: "updated",
+      }),
+    ).rejects.toThrow(
+      "Editor request timed out after 10ms while trying to write /tmp/output.ts",
+    );
+    expect(signal?.aborted).toBe(true);
+  });
+
+  test("successful editor requests clear their timeout", async () => {
+    let signal: AbortSignal | undefined;
+    const tool = editorTool("read_editor_buffer", (_method, _params, options) => {
+      signal = options?.cancellationSignal;
+      return Promise.resolve({ content: "unsaved buffer" });
+    });
+
+    const result = await tool.execute("call-read", { path: "/tmp/input.ts" });
+    expect(result).toEqual({
+      content: [{ type: "text", text: "unsaved buffer" }],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(signal?.aborted).toBe(false);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "types": ["bun-types"],
     "verbatimModuleSyntax": true
   },
-  "include": ["src/**/*.ts", "test-client.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts", "test-client.ts"]
 }


### PR DESCRIPTION
## Summary
- time out editor-backed read and write requests after 30 seconds
- send cooperative ACP cancellation while guaranteeing the local tool call fails instead of hanging
- add regression coverage for stuck reads, stuck writes, and successful timeout cleanup, and run tests in CI

## Before / after
Before, an ACP client that silently dropped an editor filesystem request could block the tool queue forever. After 30 seconds, the adapter now reports a specific tool error and can continue processing later work.

## Validation
- `bun run check`
- `bun test --rerun-each 20` (60 passes)

Closes #13.

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)