### PR TITLE
fix: harden ACP lifecycle and add client integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,18 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Typecheck, test, and build
+      # bun test includes the deterministic acpx client compatibility suite.
+      - name: Typecheck, test (including acpx), and build
         run: bun run check
+
+      # Keep the credential on trusted main-branch code. Pull requests still run
+      # the deterministic acpx suite above, including forks and Dependabot.
+      - name: Create a Letta Cloud session through acpx
+        if: github.event_name == 'push'
+        env:
+          LETTA_API_KEY: ${{ secrets.LETTA_API_KEY }}
+          LETTA_ACP_TEST_AGENT_ID: ${{ vars.LETTA_ACP_TEST_AGENT_ID }}
+        run: bun run test:acpx:live
 
       - name: Pack and install as a consumer
         shell: bash

--- a/.skills/working-on-letta-acp/SKILL.md
+++ b/.skills/working-on-letta-acp/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: working-on-letta-acp
+description: Develops and tests the letta-ai/letta-acp adapter. Use when changing ACP protocol handling, Letta Agent SDK integration, sessions, streaming, tool calls, approvals, cancellation, editor filesystem delegation, slash commands, backends, acpx compatibility, packaging, or CI in this repository.
+---
+
+# Working on letta-acp
+
+Treat this repository as a protocol adapter with three independently meaningful boundaries:
+
+1. ACP clients speak JSON-RPC over stdio to `src/index.ts`.
+2. `src/agent.ts` translates ACP sessions and updates to the Letta Agent SDK.
+3. The SDK reaches a local, remote, Cloud, or Cloud-OAuth Letta runtime.
+
+Prove the boundary affected by the change instead of relying only on unit-level mocks.
+
+## Start with the owning code
+
+- `src/index.ts`: stdio transport and ACP method registration.
+- `src/agent.ts`: sessions, prompts, streaming, approvals, cancellation, and lifecycle state.
+- `src/config.ts`: environment variables and backend selection.
+- `src/editor-tools.ts`: ACP client filesystem delegation.
+- `src/history-replay.ts`: `session/load` transcript replay.
+- `src/session-modes.ts`: adapter-enforced permission modes.
+- `src/slash-commands.ts`: advertised and executed slash commands.
+- `src/tool-info.ts`: streamed tool-input accumulation, titles, kinds, and locations.
+- `test/agent-integration.test.ts`: deterministic SDK/app-server lifecycle coverage.
+- `test/acpx-client.test.ts`: real `acpx` client plus real adapter stdio entrypoint against a fake app server.
+- `test/acpx-live.ts`: credentialed `acpx` → adapter → Letta Cloud session check.
+
+Read the relevant implementation and adjacent tests before editing. For lifecycle work, trace the full event order across both ACP and SDK messages; do not infer correctness from one terminal result.
+
+## Choose the right test boundary
+
+### Pure mapping or formatting
+
+Add focused Bun tests beside the owning module. Include fragmented, malformed, duplicate, and ordinary inputs when the code consumes streamed data.
+
+### SDK/app-server lifecycle
+
+Extend `test/agent-integration.test.ts` and its `FakeAppServer`. Exercise realistic control and stream events, including:
+
+- tool-call fragments followed by results;
+- permission requests correlated by `tool_call_id`;
+- approval continuation rounds;
+- `WAITING_ON_INPUT` with and without `active_run_ids`;
+- cancellation while work or permission requests remain pending;
+- delayed, duplicate, and missing terminal events.
+
+Assert both the returned ACP `stopReason` and the ordered `session/update` lifecycle. A green direct-method test does not prove stdio client compatibility.
+
+### ACP client compatibility
+
+Run:
+
+```bash
+bun run test:acpx
+```
+
+This invokes the pinned published `acpx` client against `src/index.ts`, using a deterministic fake app server. Extend `test/acpx-client.test.ts` when changing initialization, session creation, prompts, update schemas, permissions, tool cards, cancellation, or output that a real ACP client consumes.
+
+Do not replace this with the bundled `test-client.ts`; that client shares this repository's assumptions and is primarily a manual debugging surface.
+
+### Live Cloud transport
+
+Run:
+
+```bash
+LETTA_API_KEY=... \
+LETTA_ACP_TEST_AGENT_ID=agent-... \
+bun run test:acpx:live
+```
+
+The live check authenticates through the Cloud backend and creates a real conversation through `acpx`. It intentionally avoids a model turn so routine CI does not depend on credits, provider limits, or model output.
+
+When explicitly validating a full model turn, use the dedicated `letta-acp-ci` agent, keep it on `letta/auto-fast`, use `--deny-all`, request an exact sentinel response, and set a finite timeout. Do not turn that model-dependent probe into required PR CI unless its funding and rate-limit ownership are stable.
+
+## Credential and CI rules
+
+- Never print API keys or OAuth tokens. Inspect only presence, prefix, or length when debugging credentials.
+- Store `LETTA_API_KEY` as an Actions secret and the non-secret agent ID as `LETTA_ACP_TEST_AGENT_ID` repository variable.
+- Never expose repository secrets to pull requests or fork-controlled code. Keep credentialed tests on trusted pushes; PRs must remain fully covered by deterministic tests.
+- Use a dedicated CI agent, not a developer's personal agent. Avoid persistent prompts or tool side effects in live checks.
+- Pin `acpx` to an exact version so client behavior changes arrive as reviewable dependency updates.
+
+## Validate changes
+
+Run the narrowest useful test while iterating, then before review run:
+
+```bash
+bun run check
+```
+
+For changes affecting the external client boundary, also run `bun run test:acpx` explicitly. For Cloud/backend/auth changes, run `bun run test:acpx:live` with the dedicated agent.
+
+When changing packaging or the bin entrypoint, preserve the CI consumer-pack test: it installs the generated tarball and negotiates ACP `initialize` through `node_modules/.bin/letta-acp`.
+
+## Review before publishing
+
+Check the actual diff for:
+
+- a regression test that reaches the reported failure boundary;
+- sibling lifecycle states, retries, cancellation, and old sessions;
+- no secret-bearing logs or fixtures;
+- no dependence on model wording in deterministic CI;
+- comments explaining non-obvious event-order or liveness logic;
+- README claims that match what CI really proves.
+
+Do not claim the ACP flow is solved when only a direct adapter method passed. State whether validation covered a unit, fake app server, real ACP client, live Cloud session, or live model turn.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,18 @@ bun install
 # smoke test with the bundled ACP client (spawns the agent over stdio)
 bun test-client.ts
 bun test-client.ts "List the files in this directory using your tools."
+
+# exercise the adapter through the real acpx client without credentials or an LLM
+bun run test:acpx
 ```
+
+The `acpx` integration test starts a deterministic fake Letta app server, then
+runs a prompt through the published `acpx` CLI and this adapter's real stdio
+entrypoint. It checks a complete tool-call lifecycle and runs as part of the
+normal `bun test` CI suite. Pushes to `main` also run `bun run test:acpx:live`,
+which authenticates to a dedicated Letta Cloud agent and creates a real session
+through acpx without spending model tokens. Locally, that command requires
+`LETTA_API_KEY` and `LETTA_ACP_TEST_AGENT_ID`.
 
 The first session creates a Letta agent and logs its id to stderr; set
 `LETTA_AGENT_ID` to that value to keep using the same agent (that's the point —

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "acp",
@@ -10,6 +9,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.0",
+        "acpx": "0.13.0",
         "typescript": "^5.9.0",
       },
     },
@@ -71,9 +71,65 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
+    "@clack/core": ["@clack/core@1.4.3", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ=="],
+
+    "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
+
     "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.10", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
@@ -241,6 +297,8 @@
 
     "@vscode/ripgrep-win32-x64": ["@vscode/ripgrep-win32-x64@1.18.0", "", { "os": "win32", "cpu": "x64" }, "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg=="],
 
+    "acpx": ["acpx@0.13.0", "", { "dependencies": { "@agentclientprotocol/sdk": "^1.3.0", "commander": "^15.0.0", "skillflag": "^0.2.1", "tsx": "^4.23.1", "zod": "^4.4.3" }, "bin": { "acpx": "dist/cli.js" } }, "sha512-EdGgMx5osY4bNpVN+7dTTT67ZXsFqx/itl4QjGYTKH/Nzm3fqGmWL3E6FjRkVrlWRpiFnRNi+J1lxUJPie4lmg=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
@@ -251,7 +309,19 @@
 
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
+    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
+
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "bare-events": ["bare-events@2.9.1", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg=="],
+
+    "bare-fs": ["bare-fs@4.7.4", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ=="],
+
+    "bare-path": ["bare-path@3.1.1", "", {}, "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ=="],
+
+    "bare-stream": ["bare-stream@2.13.3", "", { "dependencies": { "b4a": "^1.8.1", "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ=="],
+
+    "bare-url": ["bare-url@2.4.6", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -285,6 +355,8 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
+
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
     "cron-parser": ["cron-parser@5.6.2", "", { "dependencies": { "luxon": "^3.7.2" } }, "sha512-yJ/G1LVir6CnlkLI40CsampPLKl1SprGGlUagWtGJxewytRVYezv5xVyzzbT+Pvzx+VIRvZVF7/a0eEMTxdnTA=="],
@@ -313,13 +385,27 @@
 
     "es-toolkit": ["es-toolkit@1.49.0", "", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
 
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "gaxios": ["gaxios@7.2.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg=="],
 
@@ -461,11 +547,17 @@
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "skillflag": ["skillflag@0.2.1", "", { "dependencies": { "@clack/prompts": "^1.0.1", "tar-stream": "^3.1.7" }, "bin": { "skillflag": "dist/bin/skillflag.js", "skill-install": "dist/bin/skill-install.js" } }, "sha512-47lfgUr6xzgljtTD5XfJrS+6muNb9R44OEr+o31Nco2R65W1xOA8Pi6QSbLa90tDYE6TqW5Hrh3N1egserGrhQ=="],
+
     "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
 
     "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
 
@@ -479,15 +571,23 @@
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
+    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
+
+    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
+
     "terminal-link": ["terminal-link@5.0.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "supports-hyperlinks": "^4.1.0" } }, "sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA=="],
 
     "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
 
     "type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
 

--- a/package.json
+++ b/package.json
@@ -34,11 +34,14 @@
     "prepare": "npm run build",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
+    "test:acpx": "bun test test/acpx-client.test.ts",
+    "test:acpx:live": "bun test/acpx-live.ts",
     "test:client": "bun test-client.ts",
     "check": "bun run test && bun run typecheck && bun run build"
   },
   "devDependencies": {
     "@types/bun": "^1.3.0",
+    "acpx": "0.13.0",
     "typescript": "^5.9.0"
   },
   "dependencies": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -18,6 +18,7 @@ import {
   type StopReason,
 } from "@agentclientprotocol/sdk";
 import {
+  type CanUseToolContext,
   type CanUseToolResponse,
   LettaAgentClient,
   type LettaCodeSession,
@@ -257,8 +258,17 @@ export class LettaAcpAgent {
       cwd: options.cwd,
       model: this.config.model,
       permissionMode: "standard" as const,
-      canUseTool: (toolName: string, toolInput: Record<string, unknown>) =>
-        this.requestToolPermission(ref.sessionId, toolName, toolInput),
+      canUseTool: (
+        toolName: string,
+        toolInput: Record<string, unknown>,
+        context?: CanUseToolContext,
+      ) =>
+        this.requestToolPermission(
+          ref.sessionId,
+          toolName,
+          toolInput,
+          context,
+        ),
       ...(editorTools.length > 0 ? { tools: editorTools } : {}),
     };
     const session = options.resumeId
@@ -689,6 +699,7 @@ export class LettaAcpAgent {
     sessionId: string,
     toolName: string,
     toolInput: Record<string, unknown>,
+    context: CanUseToolContext | undefined,
   ): Promise<CanUseToolResponse> {
     const state = this.sessions.get(sessionId);
     if (!state) {
@@ -714,6 +725,7 @@ export class LettaAcpAgent {
       state.clientContext,
       toolName,
       toolInput,
+      context,
     );
   }
 
@@ -723,20 +735,29 @@ export class LettaAcpAgent {
     cx: AgentContext,
     toolName: string,
     toolInput: Record<string, unknown>,
+    context: CanUseToolContext | undefined,
   ): Promise<CanUseToolResponse> {
     if (modeAutoAllows(state.modeId, toolName)) {
       log(`auto-allowing ${toolName} (mode ${state.modeId})`);
       return { behavior: "allow", updatedInput: toolInput };
     }
-    log(`permission requested for ${toolName}`);
+    log(
+      `permission requested for ${toolName}` +
+        (state.promptActive ? "" : " (outside a prompt turn)"),
+    );
     if (state.alwaysAllowed.has(toolName)) {
       return { behavior: "allow", updatedInput: toolInput };
     }
 
+    // The approval carries the id of the tool call it belongs to. Without it
+    // the client gets a permission card that matches no streamed tool call:
+    // guessing by name attaches to the wrong card when several calls are in
+    // flight, and the synthetic id orphans the card entirely.
     const toolCallId =
-      state.lastToolCall?.name === toolName
+      context?.toolCallId ??
+      (state.lastToolCall?.name === toolName
         ? state.lastToolCall.id
-        : `${toolName}_${crypto.randomUUID()}`;
+        : `${toolName}_${crypto.randomUUID()}`);
     const params = {
       sessionId,
       toolCall: {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -90,11 +90,20 @@ const LOAD_HISTORY_LIMIT = 200;
  */
 const DEFAULT_OUT_OF_TURN_PERMISSION_TIMEOUT_MS = 300_000;
 
+/**
+ * How long to keep a turn open after the server reported completion while
+ * still listing active runs. Long enough to cover the next model step, short
+ * enough that a server which never speaks again cannot wedge the prompt.
+ */
+const DEFAULT_PREMATURE_RESULT_GRACE_MS = 30_000;
+
 /** Safety cap on stream rounds while waiting for a slash command to finish. */
 const EXECUTE_COMMAND_MAX_ROUNDS = 50;
 
 type PumpOutcome =
   | { kind: "result"; result: SDKResultMessage }
+  /** Turn reported complete while the server still listed active runs. */
+  | { kind: "premature"; result: SDKResultMessage }
   | { kind: "idle" }
   | { kind: "stream_end" };
 
@@ -116,6 +125,7 @@ export class LettaAcpAgent {
   private readonly config: LettaAcpConfig;
   private readonly client: LettaAgentClient;
   private readonly outOfTurnPermissionTimeoutMs: number;
+  private readonly prematureResultGraceMs: number;
   private readonly sessions = new Map<string, AcpSessionState>();
   private agentIdPromise: Promise<string> | null = null;
   private clientFsCaps: EditorFsCapabilities = {
@@ -129,6 +139,8 @@ export class LettaAcpAgent {
     this.outOfTurnPermissionTimeoutMs =
       config.outOfTurnPermissionTimeoutMs ??
       DEFAULT_OUT_OF_TURN_PERMISSION_TIMEOUT_MS;
+    this.prematureResultGraceMs =
+      config.prematureResultGraceMs ?? DEFAULT_PREMATURE_RESULT_GRACE_MS;
   }
 
   async initialize(params: InitializeRequest): Promise<InitializeResponse> {
@@ -340,19 +352,33 @@ export class LettaAcpAgent {
       // first round to its result, then pump recovery rounds (blocking on the
       // stream while approvals resolve) until the run goes idle.
       let mode: "turn" | "recovery" = "turn";
+      let graceMs: number | undefined;
       while (true) {
         const outcome = await this.pumpStream(
           params.sessionId,
           state,
           cx,
           mode,
+          graceMs,
         );
         if (state.cancelled) return { stopReason: "cancelled" };
         switch (outcome.kind) {
+          case "premature": {
+            // The SDK ends its stream on any result, so the only way to stay
+            // with the run is another round — the same recovery the
+            // approval_conflict path uses, but on a deadline in case the
+            // server really was done.
+            const runIds = outcome.result.runIds?.join(", ") ?? "unknown";
+            log(`turn reported complete while runs are active (${runIds})`);
+            mode = "recovery";
+            graceMs = this.prematureResultGraceMs;
+            continue;
+          }
           case "result": {
             const result = outcome.result;
             if (!result.success && result.errorCode === "approval_conflict") {
               mode = "recovery";
+              graceMs = undefined;
               continue;
             }
             return this.toPromptResponse(state, result);
@@ -509,14 +535,46 @@ export class LettaAcpAgent {
     state: AcpSessionState,
     cx: AgentContext,
     mode: "turn" | "recovery",
+    firstMessageDeadlineMs?: number,
   ): Promise<PumpOutcome> {
     let sawActivity = false;
     let idleStatusCount = 0;
-    for await (const message of state.session.stream()) {
+    let activeRunIds: readonly string[] = [];
+
+    const stream = state.session.stream()[Symbol.asyncIterator]();
+    let awaitingFirstMessage = true;
+    while (true) {
+      const pending = stream.next();
+      // Only the first message of a grace round is raced: a server that went
+      // quiet after contradicting itself must not wedge the prompt.
+      const step =
+        awaitingFirstMessage && firstMessageDeadlineMs !== undefined
+          ? await raceDeadline(pending, firstMessageDeadlineMs)
+          : await pending;
+      if (!step) {
+        log("no further activity during the grace round; ending turn");
+        return { kind: "idle" };
+      }
+      awaitingFirstMessage = false;
+      if (step.done) break;
+      const message = step.value;
+
       if (message.type === "result") {
+        // An idle loop status that still lists active runs makes the SDK
+        // synthesize a successful, stop-reason-less turn result. Taking it at
+        // face value ends the prompt mid-run, stranding the tool calls that
+        // are still streaming and pushing their approvals outside the turn.
+        if (
+          message.success &&
+          message.stopReason == null &&
+          activeRunIds.length > 0
+        ) {
+          return { kind: "premature", result: message };
+        }
         return { kind: "result", result: message };
       }
       if (message.type === "loop_status") {
+        activeRunIds = message.activeRunIds;
         // An abort that lands before the run produces output never gets a
         // terminal result from the SDK — the return to WAITING_ON_INPUT is
         // the only end-of-turn signal, in "turn" mode too.
@@ -855,6 +913,23 @@ export class LettaAcpAgent {
       `created agent ${agentId} — set LETTA_AGENT_ID=${agentId} to keep using it`,
     );
     return agentId;
+  }
+}
+
+/** Awaits `pending`, or resolves null when the deadline expires first. */
+async function raceDeadline<T>(
+  pending: Promise<T>,
+  timeoutMs: number,
+): Promise<T | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), timeoutMs);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([pending, deadline]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,11 @@ export interface LettaAcpConfig {
    * ACP client has no obligation to answer. Defaults to five minutes.
    */
   outOfTurnPermissionTimeoutMs?: number;
+  /**
+   * How long a turn stays open after the server reports completion while still
+   * listing active runs. Defaults to 30 seconds.
+   */
+  prematureResultGraceMs?: number;
 }
 
 const PERMISSION_MODES: PermissionMode[] = [

--- a/test/acpx-client.test.ts
+++ b/test/acpx-client.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+interface RuntimeScope {
+  agent_id: string;
+  conversation_id: string;
+}
+
+type WireMessage = Record<string, unknown>;
+
+const servers: Array<ReturnType<typeof Bun.serve>> = [];
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.stop(true);
+  for (const directory of tempDirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function startFakeAppServer() {
+  const server = Bun.serve<{ channel: "control" | "stream" }>({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request, server) {
+      const channel = new URL(request.url).searchParams.get("channel") === "stream"
+        ? "stream"
+        : "control";
+      if (server.upgrade(request, { data: { channel } })) return;
+      return new Response("Expected websocket upgrade", { status: 426 });
+    },
+    websocket: {
+      message(socket, data) {
+        const message = JSON.parse(String(data)) as WireMessage;
+        if (socket.data.channel !== "control") return;
+
+        switch (message.type) {
+          case "runtime_start": {
+            const requestId = requiredString(message.request_id);
+            socket.send(JSON.stringify({
+              type: "runtime_start_response",
+              request_id: requestId,
+              success: true,
+              runtime: TEST_RUNTIME,
+              agent: { id: TEST_RUNTIME.agent_id, model: "test/model", tools: [] },
+              conversation: {
+                id: TEST_RUNTIME.conversation_id,
+                agent_id: TEST_RUNTIME.agent_id,
+              },
+            }));
+            return;
+          }
+          case "conversation_messages_list":
+            socket.send(JSON.stringify({
+              type: "conversation_messages_list_response",
+              request_id: requiredString(message.request_id),
+              success: true,
+              messages: [],
+              has_more: false,
+            }));
+            return;
+          case "input": {
+            const payload = message.payload as WireMessage;
+            if (payload.kind !== "create_message") return;
+            sendDelta(socket, {
+              message_type: "tool_call_message",
+              run_id: "run-acpx",
+              tool_calls: [{
+                id: "call-acpx",
+                name: "Read",
+                arguments: JSON.stringify({ file_path: "/tmp/example.txt" }),
+              }],
+            });
+            sendDelta(socket, {
+              message_type: "tool_return_message",
+              run_id: "run-acpx",
+              tool_call_id: "call-acpx",
+              tool_return: "example contents",
+              status: "success",
+            });
+            sendDelta(socket, {
+              message_type: "assistant_message",
+              run_id: "run-acpx",
+              content: "ACPX_OK",
+            });
+            sendDelta(socket, {
+              message_type: "stop_reason",
+              run_id: "run-acpx",
+              stop_reason: "end_turn",
+            });
+            return;
+          }
+        }
+      },
+    },
+  });
+  servers.push(server);
+  return `ws://${server.hostname}:${server.port}`;
+}
+
+const TEST_RUNTIME: RuntimeScope = {
+  agent_id: "agent-acpx-test",
+  conversation_id: "conv-acpx-test",
+};
+
+function sendDelta(
+  socket: { send(data: string): unknown },
+  delta: WireMessage,
+): void {
+  socket.send(JSON.stringify({
+    type: "stream_delta",
+    runtime: TEST_RUNTIME,
+    delta,
+  }));
+}
+
+function requiredString(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("Expected a non-empty request id");
+  }
+  return value;
+}
+
+async function runAcpx(format: "json" | "quiet") {
+  const home = mkdtempSync(join(tmpdir(), "letta-acp-acpx-"));
+  tempDirs.push(home);
+  const appServerUrl = startFakeAppServer();
+  const acpxPath = join(import.meta.dir, "..", "node_modules", ".bin", "acpx");
+  const agentPath = join(import.meta.dir, "..", "src", "index.ts");
+  const child = Bun.spawn(
+    [
+      acpxPath,
+      "--agent",
+      `${process.execPath} ${agentPath}`,
+      "--format",
+      format,
+      "--timeout",
+      "5",
+      "exec",
+      "Exercise the ACP tool lifecycle.",
+    ],
+    {
+      cwd: join(import.meta.dir, ".."),
+      env: {
+        ...process.env,
+        HOME: home,
+        LETTA_ACP_BACKEND: "remote",
+        LETTA_APP_SERVER_URL: appServerUrl,
+        LETTA_AGENT_ID: TEST_RUNTIME.agent_id,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`acpx exited ${exitCode}:\n${stderr}\n${stdout}`);
+  }
+  return { stdout, stderr };
+}
+
+describe("acpx client compatibility", () => {
+  test("completes a prompt through a real ACP client", async () => {
+    const { stdout } = await runAcpx("quiet");
+    expect(stdout.trim()).toBe("ACPX_OK");
+  }, 10_000);
+
+  test("emits a complete tool lifecycle as ACP notifications", async () => {
+    const { stdout } = await runAcpx("json");
+    const messages = stdout
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as WireMessage);
+    const updates = messages
+      .filter((message) => message.method === "session/update")
+      .map((message) => (message.params as WireMessage).update as WireMessage);
+
+    expect(updates).toContainEqual(expect.objectContaining({
+      sessionUpdate: "tool_call",
+      toolCallId: "call-acpx",
+      status: "in_progress",
+    }));
+    expect(updates).toContainEqual(expect.objectContaining({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "call-acpx",
+      status: "completed",
+    }));
+    expect(updates).toContainEqual({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "ACPX_OK" },
+    });
+  }, 10_000);
+});

--- a/test/acpx-live.ts
+++ b/test/acpx-live.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const apiKey = process.env.LETTA_API_KEY;
+const agentId = process.env.LETTA_ACP_TEST_AGENT_ID;
+if (!apiKey || !agentId) {
+  throw new Error(
+    "Live ACP smoke test requires LETTA_API_KEY and LETTA_ACP_TEST_AGENT_ID.",
+  );
+}
+
+const root = join(import.meta.dir, "..");
+const home = mkdtempSync(join(tmpdir(), "letta-acp-live-"));
+const acpxPath = join(root, "node_modules", ".bin", "acpx");
+const agentPath = join(root, "src", "index.ts");
+
+try {
+  const child = Bun.spawn(
+    [
+      acpxPath,
+      "--agent",
+      `${process.execPath} ${agentPath}`,
+      "--format",
+      "json",
+      "--timeout",
+      "60",
+      "sessions",
+      "new",
+    ],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        HOME: home,
+        LETTA_ACP_BACKEND: "cloud",
+        LETTA_AGENT_ID: agentId,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`acpx exited ${exitCode}:\n${stderr}\n${stdout}`);
+  }
+
+  const result = JSON.parse(stdout.trim()) as Record<string, unknown>;
+  if (
+    result.action !== "session_ensured" ||
+    result.created !== true ||
+    typeof result.acpxSessionId !== "string" ||
+    !result.acpxSessionId.startsWith("conv-")
+  ) {
+    throw new Error(`Unexpected live ACP session result: ${stdout.trim()}`);
+  }
+  console.log("Live acpx → letta-acp → Letta Cloud session smoke test passed.");
+} finally {
+  rmSync(home, { recursive: true, force: true });
+}

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -85,7 +85,14 @@ class FakeAppServer {
     });
   }
 
-  requestPermissionAfterPrompt(): void {
+  requestPermissionAfterPrompt(
+    overrides: {
+      requestId?: string;
+      toolName?: string;
+      toolCallId?: string;
+      input?: Record<string, unknown>;
+    } = {},
+  ): void {
     const socket = this.activeControlSocket;
     const runtime = this.activeRuntime;
     if (!socket || !runtime) {
@@ -93,13 +100,13 @@ class FakeAppServer {
     }
     socket.push({
       type: "control_request",
-      request_id: "approval-request-after-prompt",
+      request_id: overrides.requestId ?? "approval-request-after-prompt",
       runtime,
       request: {
         subtype: "can_use_tool",
-        tool_name: "Bash",
-        tool_call_id: "call-after-prompt",
-        input: {
+        tool_name: overrides.toolName ?? "Bash",
+        tool_call_id: overrides.toolCallId ?? "call-after-prompt",
+        input: overrides.input ?? {
           command: "pwd",
           description: "Show working directory after prompt",
         },
@@ -494,6 +501,48 @@ describe("Agent SDK app-server integration", () => {
       );
       // Out-of-turn requests carry a deadline the client can observe.
       expect(permissionSignals.at(-1)).toBeInstanceOf(AbortSignal);
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("attaches a permission request to the tool call it belongs to", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context, permissionRequests } = createContext();
+
+    try {
+      const session = await openSession(agent, context);
+      // Leaves a streamed Bash call as the most recent one, so name matching
+      // cannot find the Write call the approval is actually for.
+      await agent.prompt(
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "fragmented prompt" }],
+        },
+        context,
+      );
+
+      const approval = server.nextApprovalResponse();
+      server.requestPermissionAfterPrompt({
+        requestId: "approval-unrelated-tool",
+        toolName: "Write",
+        toolCallId: "call-write",
+        input: { file_path: "/tmp/example.ts" },
+      });
+      await approval;
+
+      // A synthetic id here would render a permission card the client can
+      // never reconcile with the tool call in the stream.
+      expect(permissionRequests.at(-1)).toEqual(
+        expect.objectContaining({
+          toolCall: expect.objectContaining({
+            toolCallId: "call-write",
+            title: "Write: /tmp/example.ts",
+            kind: "edit",
+          }),
+        }),
+      );
     } finally {
       agent.shutdown();
     }

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -209,6 +209,22 @@ class FakeAppServer {
       this.streamFragmentedToolCall(socket, runtime);
       return;
     }
+    if (promptText.includes("busy idle prompt")) {
+      this.reportIdleWhileRunning(socket, runtime, { thenContinue: true });
+      return;
+    }
+    if (promptText.includes("silent idle prompt")) {
+      this.reportIdleWhileRunning(socket, runtime, { thenContinue: false });
+      return;
+    }
+    if (promptText.includes("busy idle prompt")) {
+      this.reportIdleWhileRunning(socket, runtime, { thenContinue: true });
+      return;
+    }
+    if (promptText.includes("silent idle prompt")) {
+      this.reportIdleWhileRunning(socket, runtime, { thenContinue: false });
+      return;
+    }
 
     const isApprovalPrompt = promptText.includes("approval prompt");
     if (isApprovalPrompt) {
@@ -289,6 +305,50 @@ class FakeAppServer {
     });
   }
 
+  /**
+   * Reports WAITING_ON_INPUT while still listing an active run — the shape
+   * that makes the SDK synthesize a successful, stop-reason-less result even
+   * though the agent is mid-step. `thenContinue` decides whether the run
+   * really was still going (after a beat, as a real server would take) or
+   * whether the status was simply stale and nothing more arrives.
+   */
+  private reportIdleWhileRunning(
+    socket: ServerSocket,
+    runtime: RuntimeScope,
+    options: { thenContinue: boolean },
+  ): void {
+    this.pushDelta(socket, runtime, {
+      message_type: "assistant_message",
+      run_id: "run-first",
+      content: "WORKING",
+    });
+    socket.push({
+      type: "update_loop_status",
+      runtime,
+      loop_status: {
+        status: "WAITING_ON_INPUT",
+        active_run_ids: ["run-second"],
+      },
+    });
+    if (!options.thenContinue) return;
+    // A real server takes a beat before the next step; without the delay the
+    // continuation lands in the same microtask batch and hides the race.
+    setTimeout(() => {
+      this.pushDelta(socket, runtime, {
+        message_type: "assistant_message",
+        run_id: "run-second",
+        content: "STILL_WORKING",
+      });
+      // The turn tracker was already consumed by the contradicted result, so
+      // the run ends the way post-approval rounds do: on a real idle status.
+      socket.push({
+        type: "update_loop_status",
+        runtime,
+        loop_status: { status: "WAITING_ON_INPUT", active_run_ids: [] },
+      });
+    }, 20);
+  }
+
   private pushDelta(
     socket: ServerSocket,
     runtime: RuntimeScope,
@@ -307,7 +367,10 @@ function requiredString(value: unknown, label: string): string {
 
 function createAgent(
   server: FakeAppServer,
-  overrides: { outOfTurnPermissionTimeoutMs?: number } = {},
+  overrides: {
+    outOfTurnPermissionTimeoutMs?: number;
+    prematureResultGraceMs?: number;
+  } = {},
 ): LettaAcpAgent {
   return new LettaAcpAgent({
     clientOptions: {
@@ -615,6 +678,56 @@ describe("Agent SDK app-server integration", () => {
         }),
       );
       expect(permissionSignals.at(-1)?.aborted).toBe(true);
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("keeps the turn open when the server is still running a job", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context, updates } = createContext();
+
+    try {
+      const session = await openSession(agent, context);
+      const result = await agent.prompt(
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "busy idle prompt" }],
+        },
+        context,
+      );
+
+      expect(result).toEqual({ stopReason: "end_turn" });
+      // Returning at the first (contradicted) completion would end the prompt
+      // before this arrived, stranding the rest of the turn outside it.
+      expect(updates).toContainEqual({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "STILL_WORKING" },
+      });
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("ends the turn when a contradicted completion is never followed up", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server, { prematureResultGraceMs: 20 });
+    const { context } = createContext();
+
+    try {
+      const session = await openSession(agent, context);
+      // The status was simply stale: nothing follows it. The grace period has
+      // to expire on its own, or the prompt would hang forever.
+      const result = await agent.prompt(
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "silent idle prompt" }],
+        },
+        context,
+      );
+
+      expect(result).toEqual({ stopReason: "end_turn" });
     } finally {
       agent.shutdown();
     }


### PR DESCRIPTION
## Summary

- correlate permission requests with their originating ACP tool call instead of relying on the most recent call
- keep prompt turns open when the app server reports completion while still listing active runs
- run the adapter through the published `acpx` client in CI, covering a complete prompt/tool lifecycle against a deterministic app-server fixture
- verify the authenticated `acpx` → adapter → Letta Cloud session boundary on trusted pushes to `main`
- add a repo-local `working-on-letta-acp` skill that guides agents to the correct architecture, test boundary, and credential-safety workflow

## Before / after

Previously, lifecycle timing was primarily exercised through direct adapter contexts, so compatibility regressions in the real stdio client boundary could pass CI. Permission and premature-completion races could also detach approvals or end a turn while work remained active.

Now those races have focused regression coverage, every PR exercises the real `acpx` client and adapter entrypoint without credentials, trusted main pushes additionally create a real Cloud-backed ACP session, and future coding agents receive the same testing and safety workflow from the repository skill.

## Limits and risk

- The credentialed Cloud check creates a session but intentionally does not invoke a model, so it verifies authentication and transport without model cost or provider flakiness.
- Pull requests and forks never receive the Cloud credential; they run the deterministic acpx suite.
- `acpx` is pinned to `0.13.0` so client behavior changes are reviewed explicitly.

## Test plan

- [x] `bun run check`
- [x] `bun run test:acpx`
- [x] `bun run test:acpx:live` with the configured dedicated Cloud agent
- [x] validate and package `.skills/working-on-letta-acp` with the bundled skill validator

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)