### PR TITLE
Support Buzz: MCP servers, client system prompts, and agent identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,15 @@ the agent answers Buzz by shelling out to the `buzz` CLI — so the CLI and the
 | `local` (default) | on this machine | on this machine | inherited from `buzz-acp` ✅ |
 | `cloud-oauth` | Letta Cloud | on this machine | inherited from `buzz-acp` ✅ |
 | `remote` | your app server | on the app server | install it there |
-| `cloud` | Letta Cloud | Letta's sandbox | not present — use MCP (below) |
+| `cloud` | Letta Cloud | Letta's sandbox | not reachable |
 
-With `cloud`, reach Buzz through an MCP server instead: MCP servers named in
-`session/new` are spawned by *this adapter*, so their tools execute next to
-the `buzz` CLI even when the agent's own tools do not. Point the harness at
-one with `BUZZ_ACP_MCP_COMMAND` (`buzz-dev-mcp` ships with Buzz and exposes
-shell, file, and search tools).
+`cloud-oauth` is the one to use for cloud-hosted agents: it keeps agent state
+in Letta Cloud while the harness — and so every tool — runs here, next to the
+CLI. Plain `cloud` puts the harness in Letta's sandbox, which has no `buzz`
+CLI, and adapter-side tools are no help either: the sandbox has no executor
+for them, so both the editor fs tools and MCP tools fail there with
+"External tool executor not set". The adapter logs a warning at session setup
+when that combination comes up.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -100,17 +100,31 @@ buzz-acp
 
 In Buzz Desktop, pick **Letta** in the agent's runtime dropdown instead.
 
-Use the `local` or `remote` backend here. The Letta harness runs `Bash` where
-*it* runs, and the agent talks to Buzz by shelling out to the `buzz` CLI — so
-tool execution has to happen on the machine that has the CLI and the
-`BUZZ_*` environment, which the `cloud` sandbox does not. `buzz-acp`
+One Letta agent backs every channel: `buzz-acp` opens one ACP session per
+channel, each becoming its own Letta conversation on the shared agent, so
+memory carries across channels while conversations stay separate. `buzz-acp`
 auto-approves permission requests, so the default `standard` mode is fine;
 set `LETTA_ACP_PERMISSION_MODE=unrestricted` to skip the approval round trip
 per tool call.
 
-One Letta agent backs every channel: `buzz-acp` opens one ACP session per
-channel, each becoming its own Letta conversation on the shared agent, so
-memory carries across channels while conversations stay separate.
+### Choosing a backend
+
+All four backends work, but they put tool execution in different places, and
+the agent answers Buzz by shelling out to the `buzz` CLI — so the CLI and the
+`BUZZ_*` environment have to be wherever the tools run:
+
+| Backend | Agent state | Tools run | Buzz CLI |
+|---------|-------------|-----------|----------|
+| `local` (default) | on this machine | on this machine | inherited from `buzz-acp` ✅ |
+| `cloud-oauth` | Letta Cloud | on this machine | inherited from `buzz-acp` ✅ |
+| `remote` | your app server | on the app server | install it there |
+| `cloud` | Letta Cloud | Letta's sandbox | not present — use MCP (below) |
+
+With `cloud`, reach Buzz through an MCP server instead: MCP servers named in
+`session/new` are spawned by *this adapter*, so their tools execute next to
+the `buzz` CLI even when the agent's own tools do not. Point the harness at
+one with `BUZZ_ACP_MCP_COMMAND` (`buzz-dev-mcp` ships with Buzz and exposes
+shell, file, and search tools).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,37 @@ To drive a **Letta Cloud** agent from Zed without putting an API key in
 }
 ```
 
+## Use from Buzz
+
+[Buzz](https://github.com/block/buzz) drives ACP agents through its `buzz-acp`
+harness: it listens for @mentions on the relay and prompts the agent, which
+replies with the `buzz` CLI. Point the harness at this adapter:
+
+```bash
+npm install -g @letta-ai/letta-acp
+
+export BUZZ_PRIVATE_KEY="nsec1..."        # the agent's Nostr key
+export BUZZ_RELAY_URL="ws://localhost:3000"
+export BUZZ_ACP_AGENT_COMMAND="letta-acp"
+export LETTA_AGENT_ID="agent-..."         # persistent Letta agent to drive
+
+buzz-acp
+```
+
+In Buzz Desktop, pick **Letta** in the agent's runtime dropdown instead.
+
+Use the `local` or `remote` backend here. The Letta harness runs `Bash` where
+*it* runs, and the agent talks to Buzz by shelling out to the `buzz` CLI — so
+tool execution has to happen on the machine that has the CLI and the
+`BUZZ_*` environment, which the `cloud` sandbox does not. `buzz-acp`
+auto-approves permission requests, so the default `standard` mode is fine;
+set `LETTA_ACP_PERMISSION_MODE=unrestricted` to skip the approval round trip
+per tool call.
+
+One Letta agent backs every channel: `buzz-acp` opens one ACP session per
+channel, each becoming its own Letta conversation on the shared agent, so
+memory carries across channels while conversations stay separate.
+
 ## Configuration
 
 The adapter reaches Letta through one of four backends, selected with
@@ -193,6 +224,8 @@ adapter and delegate to the ACP client.
 | Session modes (`session/set_mode`: standard / acceptEdits / unrestricted) | ✅ |
 | Slash commands (`available_commands_update`, ~30 commands + skills) | ✅ |
 | Client fs delegation (`fs/read_text_file`, `fs/write_text_file`) | ✅ via external tools |
+| MCP servers from `session/new` / `session/load` | ✅ stdio only, via external tools |
+| Client-supplied `systemPrompt` on `session/new` | ✅ delivered with the session's first prompt |
 | Client terminal delegation (`terminal/*`) | ❌ (planned) |
 | Plan updates (`plan` from TodoWrite) | ❌ (planned) |
 
@@ -265,3 +298,16 @@ open and the built-ins otherwise. Both go through the normal permission flow.
 Clients that don't advertise fs capabilities get no extra tools and everything
 runs Letta-side as before. Terminal delegation (`terminal/*`) is the remaining
 piece.
+
+## MCP servers (external tools)
+
+Clients pass a list of MCP servers in `session/new` and `session/load`. The
+adapter is the MCP client for those: it spawns each **stdio** server in the
+session's `cwd`, lists its tools once at session setup, and registers each as
+a Letta external tool named `mcp__<server>__<tool>`, proxying `tools/call`
+when the model invokes one. The servers are shut down with the session.
+
+A server that fails to start, or whose tool list fails, is logged to stderr
+and skipped — a broken MCP server never fails `session/new`. The http and sse
+transports are not supported (they are skipped with a warning), which is why
+`initialize` advertises no `mcpCapabilities`.

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@agentclientprotocol/sdk": "^1.3.0",
         "@letta-ai/letta-agent-sdk": "^0.5.4",
         "@letta-ai/letta-code": "0.29.9",
+        "@modelcontextprotocol/sdk": "1.30.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.0",
@@ -134,6 +135,8 @@
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
+    "@hono/node-server": ["@hono/node-server@2.0.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg=="],
+
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -193,6 +196,8 @@
     "@letta-ai/trajectory": ["@letta-ai/trajectory@0.2.0", "", {}, "sha512-biCyT0z8nh4Q8kIqBrPgmzoalacPmosmCpvEjdN9ILpL85+T75b8ahcN9MHPHQUVRj/J7UyQuRahJ4/JdrpCcA=="],
 
     "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
@@ -298,9 +303,15 @@
 
     "@vscode/ripgrep-win32-x64": ["@vscode/ripgrep-win32-x64@1.18.0", "", { "os": "win32", "cpu": "x64" }, "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "acpx": ["acpx@0.13.0", "", { "dependencies": { "@agentclientprotocol/sdk": "^1.3.0", "commander": "^15.0.0", "skillflag": "^0.2.1", "tsx": "^4.23.1", "zod": "^4.4.3" }, "bin": { "acpx": "dist/cli.js" } }, "sha512-EdGgMx5osY4bNpVN+7dTTT67ZXsFqx/itl4QjGYTKH/Nzm3fqGmWL3E6FjRkVrlWRpiFnRNi+J1lxUJPie4lmg=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -328,6 +339,8 @@
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
@@ -337,6 +350,12 @@
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -358,9 +377,21 @@
 
     "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
     "cron-parser": ["cron-parser@5.6.2", "", { "dependencies": { "luxon": "^3.7.2" } }, "sha512-yJ/G1LVir6CnlkLI40CsampPLKl1SprGGlUagWtGJxewytRVYezv5xVyzzbT+Pvzx+VIRvZVF7/a0eEMTxdnTA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
@@ -372,6 +403,8 @@
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -380,19 +413,45 @@
 
     "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "es-toolkit": ["es-toolkit@1.49.0", "", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
 
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.6.1", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA=="],
+
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
@@ -400,13 +459,23 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "gaxios": ["gaxios@7.2.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg=="],
 
@@ -414,29 +483,51 @@
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "google-auth-library": ["google-auth-library@10.9.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "has-flag": ["has-flag@5.0.1", "", {}, "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
+    "hono": ["hono@4.12.32", "", {}, "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg=="],
+
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ink": ["ink@7.1.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w=="],
 
     "ink-link": ["ink-link@5.0.0", "", { "dependencies": { "terminal-link": "^5.0.0" }, "peerDependencies": { "ink": ">=6" } }, "sha512-TFDXc/0mwUW7LMjsr0/LeLxPVV5BnHDuDQff9RCgP4rb3R+V/4dIwGBZbCevcJZtQnVcW+Iz1LUrUbpq+UDwYA=="],
+
+    "ip-address": ["ip-address@10.3.1", "", {}, "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
@@ -446,13 +537,23 @@
 
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.4", "", {}, "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
@@ -468,7 +569,13 @@
 
     "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 
@@ -480,6 +587,10 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
@@ -488,6 +599,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
@@ -495,6 +608,14 @@
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
@@ -508,15 +629,31 @@
 
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
 
     "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@18.2.0", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="],
 
@@ -530,21 +667,45 @@
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
     "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "shiki": ["shiki@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1", "@shikijs/engine-javascript": "4.3.1", "@shikijs/engine-oniguruma": "4.3.1", "@shikijs/langs": "4.3.1", "@shikijs/themes": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -557,6 +718,8 @@
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
 
@@ -582,6 +745,8 @@
 
     "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
@@ -591,6 +756,8 @@
     "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
 
     "type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
@@ -608,15 +775,23 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
 
     "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
@@ -641,6 +816,10 @@
     "@shikijs/transformers/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
     "@shikijs/transformers/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@pierre/diffs/shiki/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.3.0",
     "@letta-ai/letta-agent-sdk": "^0.5.4",
-    "@letta-ai/letta-code": "0.29.9"
+    "@letta-ai/letta-code": "0.29.9",
+    "@modelcontextprotocol/sdk": "1.30.0"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -15,6 +15,9 @@ import {
   type PromptRequest,
   type PromptResponse,
   type RequestPermissionResponse,
+  type SessionConfigOption,
+  type SetSessionConfigOptionRequest,
+  type SetSessionConfigOptionResponse,
   type SetSessionModeRequest,
   type SetSessionModeResponse,
   type StopReason,
@@ -37,6 +40,11 @@ import {
 } from "./editor-tools.js";
 import { historyToUpdates } from "./history-replay.js";
 import { connectMcpServers, type McpBridge } from "./mcp-tools.js";
+import {
+  buildModelOption,
+  MODEL_CONFIG_ID,
+  withCurrentValue,
+} from "./model-options.js";
 import { withAcpRequestTimeout } from "./request-timeout.js";
 import {
   isSessionModeId,
@@ -85,6 +93,8 @@ interface AcpSessionState {
   cwd: string;
   /** MCP servers the client attached to this session. */
   mcp: McpBridge;
+  /** Session config options published to the client (the model selector). */
+  configOptions: SessionConfigOption[];
   /**
    * Client-supplied system prompt awaiting delivery, prepended to the next
    * prompt because Letta has no per-session system prompt to set.
@@ -121,6 +131,13 @@ const DEFAULT_OUT_OF_TURN_PERMISSION_TIMEOUT_MS = 300_000;
  */
 const DEFAULT_PREMATURE_RESULT_GRACE_MS = 30_000;
 
+/**
+ * How long `session/new` waits for the model catalog before answering without
+ * one. Clients read the model picker off the session response, so the lookup
+ * is worth a brief wait — but never at the cost of session creation.
+ */
+const MODEL_CATALOG_DEADLINE_MS = 2_000;
+
 /** Safety cap on stream rounds while waiting for a slash command to finish. */
 const EXECUTE_COMMAND_MAX_ROUNDS = 50;
 
@@ -152,6 +169,7 @@ export class LettaAcpAgent {
   private readonly prematureResultGraceMs: number;
   private readonly sessions = new Map<string, AcpSessionState>();
   private agentIdPromise: Promise<string> | null = null;
+  private modelOptionPromise: Promise<SessionConfigOption | null> | null = null;
   private clientFsCaps: EditorFsCapabilities = {
     readTextFile: false,
     writeTextFile: false,
@@ -210,7 +228,14 @@ export class LettaAcpAgent {
     });
     log(`session ${sessionId} -> agent ${agentId} (cwd: ${params.cwd})`);
     this.announceCommands(sessionId, cx);
-    return { sessionId, modes: sessionModeState(state.modeId) };
+    this.publishLateModelOptions(sessionId, state, cx);
+    return {
+      sessionId,
+      modes: sessionModeState(state.modeId),
+      ...(state.configOptions.length > 0
+        ? { configOptions: state.configOptions }
+        : {}),
+    };
   }
 
   async loadSession(
@@ -248,7 +273,40 @@ export class LettaAcpAgent {
     }
     log(`loaded session ${sessionId} (${updates.length} replayed updates)`);
     this.announceCommands(sessionId, cx);
-    return { modes: sessionModeState(state.modeId) };
+    this.publishLateModelOptions(sessionId, state, cx);
+    return {
+      modes: sessionModeState(state.modeId),
+      ...(state.configOptions.length > 0
+        ? { configOptions: state.configOptions }
+        : {}),
+    };
+  }
+
+  /**
+   * Applies a client's config-option change. Only the model selector is
+   * published, so `model` is the only id that can arrive here.
+   */
+  async setSessionConfigOption(
+    params: SetSessionConfigOptionRequest,
+  ): Promise<SetSessionConfigOptionResponse> {
+    const state = this.sessions.get(params.sessionId);
+    if (!state) {
+      throw new Error(`Unknown session: ${params.sessionId}`);
+    }
+    if (params.configId !== MODEL_CONFIG_ID) {
+      throw new Error(`Unknown config option: ${params.configId}`);
+    }
+    const value = params.value;
+    if (typeof value !== "string") {
+      throw new Error("The model option takes a model handle");
+    }
+    const result = await state.session.updateModel(value);
+    const applied = result.modelHandle ?? result.modelId ?? value;
+    state.configOptions = state.configOptions.map((option) =>
+      option.id === MODEL_CONFIG_ID ? withCurrentValue(option, applied) : option,
+    );
+    log(`session ${params.sessionId} model -> ${applied}`);
+    return { configOptions: state.configOptions };
   }
 
   async setSessionMode(
@@ -367,9 +425,83 @@ export class LettaAcpAgent {
       cwd: options.cwd,
       mcp,
       pendingSystemPrompt: options.systemPrompt?.trim() || null,
+      configOptions: await this.modelConfigOptions(session),
     };
     this.sessions.set(sessionId, state);
     return { sessionId, state };
+  }
+
+  /**
+   * The session's model selector, or none if the catalog is not ready in time.
+   *
+   * A model list is a nicety, not a precondition for talking to the agent, so
+   * the lookup never blocks `session/new` for longer than
+   * {@link MODEL_CATALOG_DEADLINE_MS}. A late or failed catalog leaves the
+   * session without a picker; {@link publishLateModelOptions} pushes one to
+   * the client if the lookup lands after the response has gone out.
+   */
+  private async modelConfigOptions(
+    session: LettaCodeSession,
+  ): Promise<SessionConfigOption[]> {
+    const catalog = this.modelOption(session);
+    const timedOut = Symbol("timeout");
+    const raced = await Promise.race([
+      catalog,
+      new Promise<typeof timedOut>((resolve) =>
+        setTimeout(() => resolve(timedOut), MODEL_CATALOG_DEADLINE_MS).unref?.(),
+      ),
+    ]);
+    if (raced === timedOut) {
+      log("model catalog is still loading; opening the session without it");
+      return [];
+    }
+    return raced ? [raced] : [];
+  }
+
+  /** Sends the model selector once a slow catalog lookup finishes. */
+  private publishLateModelOptions(
+    sessionId: string,
+    state: AcpSessionState,
+    cx: AgentContext,
+  ): void {
+    if (state.configOptions.length > 0) return;
+    void this.modelOption(state.session).then((option) => {
+      if (!option || state.configOptions.length > 0) return;
+      state.configOptions = [option];
+      void cx.notify(methods.client.session.update, {
+        sessionId,
+        update: { sessionUpdate: "config_option_update", configOptions: [option] },
+      });
+    });
+  }
+
+  /**
+   * The model selector for this adapter's agent, fetched once per process.
+   *
+   * The catalog is a property of the backend, not of a session, so the first
+   * lookup is shared: later sessions publish their picker without a round trip.
+   */
+  private modelOption(
+    session: LettaCodeSession,
+  ): Promise<SessionConfigOption | null> {
+    this.modelOptionPromise ??= session
+      .listModels()
+      .then((models) => {
+        const option = buildModelOption(models, this.config.model);
+        if (!option) {
+          log("no models available for this agent; no model selector");
+          return null;
+        }
+        const count = option.type === "select" ? option.options.length : 0;
+        log(`advertising ${count} models (current: ${option.currentValue})`);
+        return option;
+      })
+      .catch((error) => {
+        log(`could not list models: ${String(error)}`);
+        this.modelOptionPromise = null;
+        return null;
+      });
+    return this.modelOptionPromise;
   }
 
   private announceCommands(sessionId: string, cx: AgentContext): void {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -305,6 +305,17 @@ export class LettaAcpAgent {
       log,
     });
     const tools = [...editorTools, ...mcp.tools];
+    if (tools.length > 0 && this.config.clientOptions.backend === "cloud") {
+      // Cloud agents run their harness in Letta's sandbox, which has no
+      // executor for tools that live in this process: the server answers such
+      // a call with "External tool executor not set". Say so once at session
+      // setup rather than leaving it to a failed tool call mid-turn.
+      log(
+        `warning: the cloud backend cannot execute adapter-side tools (${tools
+          .map((tool) => tool.name)
+          .join(", ")}); use LETTA_ACP_BACKEND=cloud-oauth for cloud agents with local tool execution`,
+      );
+    }
     const sessionOptions = {
       cwd: options.cwd,
       model: this.config.model,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import {
   type AgentContext,
   type CancelNotification,
@@ -6,6 +7,7 @@ import {
   type InitializeResponse,
   type LoadSessionRequest,
   type LoadSessionResponse,
+  type McpServer,
   methods,
   type NewSessionRequest,
   type NewSessionResponse,
@@ -34,6 +36,7 @@ import {
   type EditorFsCapabilities,
 } from "./editor-tools.js";
 import { historyToUpdates } from "./history-replay.js";
+import { connectMcpServers, type McpBridge } from "./mcp-tools.js";
 import { withAcpRequestTimeout } from "./request-timeout.js";
 import {
   isSessionModeId,
@@ -80,10 +83,25 @@ interface AcpSessionState {
   modeId: PermissionMode;
   /** Session working directory (for project skill discovery). */
   cwd: string;
+  /** MCP servers the client attached to this session. */
+  mcp: McpBridge;
+  /**
+   * Client-supplied system prompt awaiting delivery, prepended to the next
+   * prompt because Letta has no per-session system prompt to set.
+   */
+  pendingSystemPrompt: string | null;
 }
 
 /** Max history messages replayed on session/load. */
 const LOAD_HISTORY_LIMIT = 200;
+
+/**
+ * Identity reported in the `initialize` response. Harnesses that multiplex
+ * several adapters (buzz-acp, for one) branch on this and display it, so the
+ * version is read from the package rather than hard-coded and left to drift.
+ */
+const AGENT_NAME = "letta-acp";
+const AGENT_VERSION = packageVersion();
 
 /**
  * Liveness bound for permission requests raised outside a prompt turn.
@@ -162,6 +180,7 @@ export class LettaAcpAgent {
         : PROTOCOL_VERSION;
     return {
       protocolVersion,
+      agentInfo: { name: AGENT_NAME, version: AGENT_VERSION },
       agentCapabilities: {
         loadSession: true,
         promptCapabilities: {
@@ -186,6 +205,8 @@ export class LettaAcpAgent {
       resumeId: null,
       agentId,
       clientContext: cx,
+      mcpServers: params.mcpServers,
+      systemPrompt: systemPromptOf(params),
     });
     log(`session ${sessionId} -> agent ${agentId} (cwd: ${params.cwd})`);
     this.announceCommands(sessionId, cx);
@@ -209,6 +230,8 @@ export class LettaAcpAgent {
       resumeId: params.sessionId,
       agentId: null,
       clientContext: cx,
+      mcpServers: params.mcpServers,
+      systemPrompt: systemPromptOf(params),
     });
     const history = await state.session.listMessages({
       order: "desc",
@@ -268,6 +291,8 @@ export class LettaAcpAgent {
     resumeId: string | null;
     agentId: string | null;
     clientContext: AgentContext;
+    mcpServers?: readonly McpServer[];
+    systemPrompt?: string | null;
   }): Promise<{ sessionId: string; state: AcpSessionState }> {
     const ref = { sessionId: options.resumeId ?? "" };
     const editorTools = createEditorTools(this.clientFsCaps, {
@@ -275,6 +300,11 @@ export class LettaAcpAgent {
       getClientContext: () =>
         this.sessions.get(ref.sessionId)?.clientContext ?? null,
     });
+    const mcp = await connectMcpServers(options.mcpServers, {
+      cwd: options.cwd,
+      log,
+    });
+    const tools = [...editorTools, ...mcp.tools];
     const sessionOptions = {
       cwd: options.cwd,
       model: this.config.model,
@@ -290,16 +320,22 @@ export class LettaAcpAgent {
           toolInput,
           context,
         ),
-      ...(editorTools.length > 0 ? { tools: editorTools } : {}),
+      ...(tools.length > 0 ? { tools } : {}),
     };
     const session = options.resumeId
       ? this.client.resumeSession(options.resumeId, sessionOptions)
       : this.client.createSession(options.agentId ?? "", sessionOptions);
     // Force runtime initialization so the conversation id exists.
-    await session.listMessages({ limit: 1 });
+    try {
+      await session.listMessages({ limit: 1 });
+    } catch (error) {
+      await mcp.close();
+      throw error;
+    }
     const sessionId = options.resumeId ?? session.conversationId;
     if (!sessionId) {
       session.close();
+      await mcp.close();
       throw new Error("Letta session did not report a conversation id");
     }
     ref.sessionId = sessionId;
@@ -318,6 +354,8 @@ export class LettaAcpAgent {
       promptActive: false,
       modeId: this.config.permissionMode,
       cwd: options.cwd,
+      mcp,
+      pendingSystemPrompt: options.systemPrompt?.trim() || null,
     };
     this.sessions.set(sessionId, state);
     return { sessionId, state };
@@ -351,7 +389,7 @@ export class LettaAcpAgent {
     try {
       const commandResponse = await this.maybeRunCommand(params, state, cx);
       if (commandResponse) return commandResponse;
-      await state.session.send(toLettaContent(params.prompt));
+      await state.session.send(withPendingSystemPrompt(state, params.prompt));
       // The Letta app-server transport completes a turn with a recoverable
       // "approval_conflict" result whenever a tool needs user approval. The
       // approval itself resolves concurrently: the server sends a
@@ -648,6 +686,7 @@ export class LettaAcpAgent {
       } catch {
         // best-effort cleanup on connection close
       }
+      void state.mcp.close();
     }
     this.sessions.clear();
   }
@@ -982,6 +1021,54 @@ async function raceDeadline<T>(
 function knownToolName(toolName: string): string | undefined {
   if (!toolName || toolName === "?") return undefined;
   return toolName;
+}
+
+/** Adapter version from package.json, or "0.0.0" if it cannot be read. */
+function packageVersion(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require("../package.json") as { version?: unknown };
+    return typeof pkg.version === "string" ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/**
+ * Reads the non-standard `systemPrompt` a client may attach to `session/new`.
+ *
+ * ACP v1 has no such field, so it arrives as an extra member (harnesses like
+ * buzz-acp send one per session). Letta agents carry their own persona and the
+ * SDK exposes no per-session system prompt, so the text is delivered as a
+ * framed preamble on the session's first prompt instead — see
+ * {@link withPendingSystemPrompt}.
+ */
+function systemPromptOf(params: unknown): string | null {
+  if (typeof params !== "object" || params === null) return null;
+  const value = (params as { systemPrompt?: unknown }).systemPrompt;
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+/**
+ * Prompt content with the session's pending system prompt prepended once.
+ *
+ * Clients that send a system prompt expect it to govern the conversation, so
+ * it leads the first message the agent sees and is then cleared.
+ */
+function withPendingSystemPrompt(
+  state: AcpSessionState,
+  blocks: ContentBlock[],
+): MessageContentItem[] {
+  const content = toLettaContent(blocks);
+  const systemPrompt = state.pendingSystemPrompt;
+  if (!systemPrompt) return content;
+  state.pendingSystemPrompt = null;
+  log("delivering client system prompt with the first prompt of the session");
+  content.unshift({
+    type: "text",
+    text: `[System instructions from the client]\n${systemPrompt}`,
+  });
+  return content;
 }
 
 /** ACP prompt content blocks -> Letta multimodal message content. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,9 @@ const connection = await acp
   .onRequest(acp.methods.agent.session.setMode, (ctx) =>
     agent.setSessionMode(ctx.params, ctx.client),
   )
+  .onRequest(acp.methods.agent.session.setConfigOption, (ctx) =>
+    agent.setSessionConfigOption(ctx.params),
+  )
   .onRequest(acp.methods.agent.session.prompt, (ctx) =>
     agent.prompt(ctx.params, ctx.client),
   )

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -1,0 +1,256 @@
+import type { McpServer } from "@agentclientprotocol/sdk";
+import type {
+  AgentToolResultContent,
+  AnyAgentTool,
+} from "@letta-ai/letta-agent-sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  getDefaultEnvironment,
+  StdioClientTransport,
+} from "@modelcontextprotocol/sdk/client/stdio.js";
+
+/** MCP servers connected for one ACP session, plus the tools they expose. */
+export interface McpBridge {
+  /** External tools to register with the Letta session. */
+  tools: AnyAgentTool[];
+  /** Disconnects every server; safe to call more than once. */
+  close(): Promise<void>;
+}
+
+interface ConnectOptions {
+  /** Working directory the servers are spawned in. */
+  cwd?: string;
+  /** Diagnostic sink (stderr in production). */
+  log?: (message: string) => void;
+}
+
+const EMPTY_BRIDGE: McpBridge = { tools: [], close: async () => {} };
+
+const CLIENT_INFO = { name: "letta-acp", version: "1" };
+
+/**
+ * Connects the MCP servers a client passed in `session/new`, exposing their
+ * tools as Letta external tools.
+ *
+ * The Letta harness has no MCP client of its own on this path, so the adapter
+ * is the client: it spawns each stdio server, lists its tools once at session
+ * setup, and proxies `tools/call` from the tool handlers the SDK registers.
+ * Tools are namespaced `mcp__<server>__<tool>` (the convention Letta and
+ * Claude Code both use) so two servers exporting `search` don't collide.
+ *
+ * A server that fails to start or list tools is logged and skipped — a broken
+ * MCP server must not fail `session/new` and take the whole session with it.
+ * Only the stdio transport is supported, which is why `initialize` advertises
+ * no `mcpCapabilities`: http/sse servers are dropped with a warning rather
+ * than silently ignored.
+ */
+export async function connectMcpServers(
+  servers: readonly McpServer[] | undefined,
+  options: ConnectOptions = {},
+): Promise<McpBridge> {
+  const log = options.log ?? (() => {});
+  if (!servers || servers.length === 0) return EMPTY_BRIDGE;
+
+  const clients: Client[] = [];
+  const tools: AnyAgentTool[] = [];
+  const taken = new Set<string>();
+
+  for (const server of servers) {
+    const transport = serverTransport(server);
+    if (!transport) {
+      log(
+        `mcp: skipping server "${server.name}" — only the stdio transport is supported`,
+      );
+      continue;
+    }
+    try {
+      const client = new Client(CLIENT_INFO);
+      await client.connect(
+        new StdioClientTransport({
+          command: transport.command,
+          args: transport.args,
+          env: { ...getDefaultEnvironment(), ...transport.env },
+          ...(options.cwd ? { cwd: options.cwd } : {}),
+          stderr: "inherit",
+        }),
+      );
+      clients.push(client);
+      const listed = await client.listTools();
+      for (const tool of listed.tools) {
+        const name = uniqueName(
+          `mcp__${sanitize(server.name)}__${sanitize(tool.name)}`,
+          taken,
+        );
+        tools.push(bridgeTool(client, server.name, tool, name));
+      }
+      log(
+        `mcp: connected "${server.name}" (${listed.tools.length} tool${
+          listed.tools.length === 1 ? "" : "s"
+        })`,
+      );
+    } catch (error) {
+      log(`mcp: server "${server.name}" unavailable: ${String(error)}`);
+    }
+  }
+
+  if (clients.length === 0) return EMPTY_BRIDGE;
+
+  let closed = false;
+  return {
+    tools,
+    close: async () => {
+      if (closed) return;
+      closed = true;
+      await Promise.all(
+        clients.map(async (client) => {
+          try {
+            await client.close();
+          } catch {
+            // best-effort cleanup: the session is going away regardless
+          }
+        }),
+      );
+    },
+  };
+}
+
+interface StdioTransportConfig {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+/**
+ * Stdio spawn config for an ACP MCP server entry, or null for the http/sse
+ * transports. The stdio variant is the untagged one in the ACP schema, so a
+ * missing `type` means stdio.
+ */
+function serverTransport(server: McpServer): StdioTransportConfig | null {
+  const type = (server as { type?: string }).type;
+  if (type !== undefined && type !== "stdio") return null;
+  const stdio = server as {
+    command?: unknown;
+    args?: unknown;
+    env?: unknown;
+  };
+  if (typeof stdio.command !== "string" || stdio.command.length === 0) {
+    return null;
+  }
+  const args = Array.isArray(stdio.args)
+    ? stdio.args.filter((arg): arg is string => typeof arg === "string")
+    : [];
+  const env: Record<string, string> = {};
+  if (Array.isArray(stdio.env)) {
+    for (const entry of stdio.env) {
+      if (!entry || typeof entry !== "object") continue;
+      const { name, value } = entry as { name?: unknown; value?: unknown };
+      if (typeof name === "string" && typeof value === "string") {
+        env[name] = value;
+      }
+    }
+  }
+  return { command: stdio.command, args, env };
+}
+
+interface McpToolDefinition {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema?: unknown;
+}
+
+function bridgeTool(
+  client: Client,
+  serverName: string,
+  tool: McpToolDefinition,
+  name: string,
+): AnyAgentTool {
+  return {
+    name,
+    label: tool.title ?? tool.name,
+    description:
+      tool.description && tool.description.trim().length > 0
+        ? tool.description
+        : `The ${tool.name} tool from the ${serverName} MCP server.`,
+    parameters: toolParameters(tool.inputSchema),
+    execute: async (_toolCallId, args, signal) => {
+      const result = await client.callTool(
+        {
+          name: tool.name,
+          arguments: isRecord(args) ? args : {},
+        },
+        undefined,
+        signal ? { signal } : undefined,
+      );
+      const content = toToolResultContent(result.content);
+      if (result.isError) {
+        throw new Error(
+          content
+            .map((item) => item.text ?? "")
+            .filter(Boolean)
+            .join("\n") || `${tool.name} failed`,
+        );
+      }
+      return { content };
+    },
+  };
+}
+
+/** MCP tool schemas are JSON Schema already; keep an object shape regardless. */
+function toolParameters(inputSchema: unknown): Record<string, unknown> {
+  if (isRecord(inputSchema) && inputSchema.type === "object") {
+    return inputSchema;
+  }
+  return { type: "object", properties: {} };
+}
+
+/**
+ * MCP content blocks -> Letta tool-result content. Text and images map
+ * directly; anything else (audio, embedded resources) is rendered as text so
+ * the model still sees it rather than silently losing the block.
+ */
+function toToolResultContent(content: unknown): AgentToolResultContent[] {
+  if (!Array.isArray(content)) return [];
+  const mapped: AgentToolResultContent[] = [];
+  for (const block of content) {
+    if (!isRecord(block)) continue;
+    if (block.type === "text" && typeof block.text === "string") {
+      mapped.push({ type: "text", text: block.text });
+      continue;
+    }
+    if (
+      block.type === "image" &&
+      typeof block.data === "string" &&
+      typeof block.mimeType === "string"
+    ) {
+      mapped.push({
+        type: "image",
+        data: block.data,
+        mimeType: block.mimeType,
+      });
+      continue;
+    }
+    mapped.push({ type: "text", text: JSON.stringify(block) });
+  }
+  return mapped;
+}
+
+/** Tool names reach the model API, which only accepts [A-Za-z0-9_-]. */
+function sanitize(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function uniqueName(name: string, taken: Set<string>): string {
+  let candidate = name;
+  let suffix = 2;
+  while (taken.has(candidate)) {
+    candidate = `${name}_${suffix}`;
+    suffix += 1;
+  }
+  taken.add(candidate);
+  return candidate;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/model-options.ts
+++ b/src/model-options.ts
@@ -1,0 +1,103 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import type { ListModelsResult } from "@letta-ai/letta-agent-sdk";
+
+/** Config option id for the model selector, per the ACP model-category convention. */
+export const MODEL_CONFIG_ID = "model";
+
+/**
+ * Letta's model catalog as an ACP session config option.
+ *
+ * Clients with a model picker — Zed's dropdown, Buzz's agent form — read the
+ * `model`-category entry of `configOptions` from `session/new`. Without one
+ * they either hide the picker or report the agent has no models, so the
+ * catalog is published at session setup and kept current through
+ * `session/set_config_option`.
+ *
+ * Entries are keyed by handle (`provider/model`), the same identifier
+ * `LETTA_ACP_MODEL` and `/model` take, so a value chosen here can be pinned in
+ * config later. Handles the user cannot actually reach are dropped; when the
+ * availability lookup itself failed (`availableHandles` is null) the full
+ * catalog is offered rather than an empty picker.
+ */
+export function buildModelOption(
+  models: ListModelsResult,
+  preferred?: string,
+): SessionConfigOption | null {
+  const available =
+    models.availableHandles == null ? null : new Set(models.availableHandles);
+  const entries = dedupeByHandle(
+    models.entries.filter(
+      (entry) => available == null || available.has(entry.handle),
+    ),
+  );
+  if (entries.length === 0) return null;
+
+  const options = entries.map((entry) => ({
+    value: entry.handle,
+    name: entry.label || entry.handle,
+    // `displayName` is the pre-rename spelling of `name`; clients that have
+    // not caught up to the rename (buzz-acp among them) read only that one.
+    displayName: entry.label || entry.handle,
+    ...(entry.description ? { description: entry.description } : {}),
+  }));
+
+  return {
+    id: MODEL_CONFIG_ID,
+    // Same story as `displayName` above: `configId` is the older spelling of
+    // `id`, and a client reading only that must still find the selector.
+    configId: MODEL_CONFIG_ID,
+    name: "Model",
+    displayName: "Model",
+    category: "model",
+    type: "select",
+    currentValue: currentHandle(entries, preferred),
+    options,
+  } as SessionConfigOption;
+}
+
+/**
+ * One option per handle.
+ *
+ * Letta lists a separate entry per reasoning tier of the same model, and they
+ * share a handle — as ACP options those would be indistinguishable duplicates,
+ * and picking one would be ambiguous. The default tier wins where present.
+ */
+function dedupeByHandle(
+  entries: ListModelsResult["entries"],
+): ListModelsResult["entries"] {
+  const byHandle = new Map<string, ListModelsResult["entries"][number]>();
+  for (const entry of entries) {
+    const existing = byHandle.get(entry.handle);
+    if (!existing || (entry.isDefault && !existing.isDefault)) {
+      byHandle.set(entry.handle, entry);
+    }
+  }
+  return [...byHandle.values()];
+}
+
+/** Replaces the current selection, keeping the option list as published. */
+export function withCurrentValue(
+  option: SessionConfigOption,
+  value: string,
+): SessionConfigOption {
+  return { ...option, currentValue: value } as SessionConfigOption;
+}
+
+/**
+ * The handle to show as selected: an explicitly configured model when it is
+ * one of the offered handles, else the catalog default, else the first entry.
+ */
+function currentHandle(
+  entries: ListModelsResult["entries"],
+  preferred?: string,
+): string {
+  const first = entries[0];
+  if (!first) throw new Error("currentHandle requires a non-empty catalog");
+  if (preferred) {
+    const match = entries.find(
+      (entry) => entry.handle === preferred || entry.id === preferred,
+    );
+    if (match) return match.handle;
+  }
+  return (entries.find((entry) => entry.isDefault) ?? first).handle;
+}

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -24,6 +24,8 @@ class FakeAppServer {
   readonly externalToolGroups: unknown[] = [];
   /** Message payloads the adapter sent as prompts, oldest first. */
   readonly promptPayloads: WireMessage[] = [];
+  /** update_model payloads the adapter sent, oldest first. */
+  readonly modelUpdates: WireMessage[] = [];
   private nextConversation = 0;
   private activeControlSocket: ServerSocket | null = null;
   private activeRuntime: RuntimeScope | null = null;
@@ -171,6 +173,49 @@ class FakeAppServer {
           request_id: requiredString(message.request_id, "enable_memfs.request_id"),
           success: true,
           memory_directory: "/tmp/letta-acp-memory",
+        });
+        return;
+      case "list_models":
+        socket.push({
+          type: "list_models_response",
+          request_id: requiredString(message.request_id, "list_models.request_id"),
+          success: true,
+          entries: [
+            {
+              id: "sonnet",
+              handle: "anthropic/claude-sonnet-4",
+              label: "Claude Sonnet 4",
+              description: "Balanced",
+              isDefault: true,
+            },
+            {
+              id: "opus",
+              handle: "anthropic/claude-opus-4",
+              label: "Claude Opus 4",
+              description: "Most capable",
+            },
+            {
+              id: "hidden",
+              handle: "openai/gpt-4.1",
+              label: "GPT-4.1",
+              description: "Not available to this user",
+            },
+          ],
+          available_handles: [
+            "anthropic/claude-sonnet-4",
+            "anthropic/claude-opus-4",
+          ],
+        });
+        return;
+      case "update_model":
+        this.modelUpdates.push(message.payload as WireMessage);
+        socket.push({
+          type: "update_model_response",
+          request_id: requiredString(message.request_id, "update_model.request_id"),
+          success: true,
+          applied_to: "agent",
+          model_handle: (message.payload as { model_handle?: string })
+            ?.model_handle,
         });
         return;
       case "conversation_messages_list":
@@ -504,6 +549,7 @@ function createAgent(
   server: FakeAppServer,
   overrides: {
     agentId?: string;
+    model?: string;
     outOfTurnPermissionTimeoutMs?: number;
     prematureResultGraceMs?: number;
   } = {},
@@ -1059,6 +1105,112 @@ describe("Agent SDK app-server integration", () => {
       await agent.cancel({ sessionId: session.sessionId });
 
       expect(await prompt).toEqual({ stopReason: "cancelled" });
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("publishes the model catalog as a session config option", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context } = createContext();
+
+    try {
+      const session = await openSession(agent, context);
+
+      // Compared as plain JSON: the pre-rename aliases are deliberately
+      // outside the current schema type.
+      expect(session.configOptions as unknown).toEqual([
+        {
+          id: "model",
+          // Pre-rename spellings ride along for clients that read only those.
+          configId: "model",
+          name: "Model",
+          displayName: "Model",
+          category: "model",
+          type: "select",
+          // Handles the availability lookup excluded are dropped, and the
+          // catalog default is preselected.
+          currentValue: "anthropic/claude-sonnet-4",
+          options: [
+            {
+              value: "anthropic/claude-sonnet-4",
+              name: "Claude Sonnet 4",
+              displayName: "Claude Sonnet 4",
+              description: "Balanced",
+            },
+            {
+              value: "anthropic/claude-opus-4",
+              name: "Claude Opus 4",
+              displayName: "Claude Opus 4",
+              description: "Most capable",
+            },
+          ],
+        },
+      ]);
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("preselects the configured model override", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server, { model: "anthropic/claude-opus-4" });
+    const { context } = createContext();
+
+    try {
+      const session = await openSession(agent, context);
+      const option = session.configOptions?.[0];
+
+      expect(option && "currentValue" in option ? option.currentValue : null).toBe(
+        "anthropic/claude-opus-4",
+      );
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("switches the model through session/set_config_option", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context } = createContext();
+
+    try {
+      const session = await openSession(agent, context);
+      const result = await agent.setSessionConfigOption({
+        sessionId: session.sessionId,
+        configId: "model",
+        value: "anthropic/claude-opus-4",
+      });
+
+      // Handles (provider/model) ride as model_handle, not the loose model id.
+      expect(server.modelUpdates).toEqual([
+        { model_handle: "anthropic/claude-opus-4" },
+      ]);
+      const option = result.configOptions[0];
+      expect(option && "currentValue" in option ? option.currentValue : null).toBe(
+        "anthropic/claude-opus-4",
+      );
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("rejects config options it does not publish", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context } = createContext();
+
+    try {
+      const session = await openSession(agent, context);
+
+      expect(
+        agent.setSessionConfigOption({
+          sessionId: session.sessionId,
+          configId: "thinking",
+          value: "high",
+        }),
+      ).rejects.toThrow("Unknown config option: thinking");
     } finally {
       agent.shutdown();
     }

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -20,6 +20,10 @@ class FakeAppServer {
   readonly runtimeStartRequestIds: string[] = [];
   readonly createdAgentBodies: WireMessage[] = [];
   readonly approvalResponses: WireMessage[] = [];
+  /** External tool groups registered with each runtime_start. */
+  readonly externalToolGroups: unknown[] = [];
+  /** Message payloads the adapter sent as prompts, oldest first. */
+  readonly promptPayloads: WireMessage[] = [];
   private nextConversation = 0;
   private activeControlSocket: ServerSocket | null = null;
   private activeRuntime: RuntimeScope | null = null;
@@ -148,6 +152,9 @@ class FakeAppServer {
         };
         this.runtimeStartRequestIds.push(requestId);
         if (createAgent?.body) this.createdAgentBodies.push(createAgent.body);
+        if (message.external_tools !== undefined) {
+          this.externalToolGroups.push(message.external_tools);
+        }
         socket.push({
           type: "runtime_start_response",
           request_id: requestId,
@@ -255,6 +262,7 @@ class FakeAppServer {
       throw new Error(`Unhandled fake input payload: ${String(payload.kind)}`);
     }
 
+    this.promptPayloads.push(payload);
     const promptText = JSON.stringify(payload.messages);
     if (promptText.includes("fragmented prompt")) {
       this.streamFragmentedToolCall(socket, runtime);
@@ -546,10 +554,18 @@ function createContext(
   return { context, updates, permissionRequests, permissionSignals };
 }
 
-async function openSession(agent: LettaAcpAgent, context: AgentContext) {
+async function openSession(
+  agent: LettaAcpAgent,
+  context: AgentContext,
+  params: Record<string, unknown> = {},
+) {
   await agent.initialize({ protocolVersion: 1, clientCapabilities: {} });
   return agent.newSession(
-    { cwd: "/tmp/letta-acp-test", mcpServers: [] },
+    {
+      cwd: "/tmp/letta-acp-test",
+      mcpServers: [],
+      ...params,
+    } as Parameters<LettaAcpAgent["newSession"]>[0],
     context,
   );
 }
@@ -1043,6 +1059,90 @@ describe("Agent SDK app-server integration", () => {
       await agent.cancel({ sessionId: session.sessionId });
 
       expect(await prompt).toEqual({ stopReason: "cancelled" });
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("identifies itself in the initialize response", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+
+    try {
+      const result = await agent.initialize({
+        protocolVersion: 1,
+        clientCapabilities: {},
+      });
+
+      expect(result.agentInfo).toMatchObject({ name: "letta-acp" });
+      expect(result.agentInfo?.version).toMatch(/^\d+\.\d+\.\d+/);
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("registers MCP server tools as external tools on the session", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context } = createContext();
+
+    try {
+      await openSession(agent, context, {
+        // MCP servers are spawned in the session cwd, so it has to exist.
+        cwd: process.cwd(),
+        mcpServers: [
+          {
+            name: "buzz",
+            command: process.execPath,
+            args: [
+              new URL("./fixtures/mock-mcp-server.ts", import.meta.url).pathname,
+            ],
+            env: [],
+          },
+        ],
+      });
+
+      const registered = JSON.stringify(server.externalToolGroups);
+      expect(registered).toContain("mcp__buzz__echo");
+      expect(registered).toContain("mcp__buzz__explode");
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("delivers a client system prompt with the first prompt only", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context } = createContext();
+
+    try {
+      const session = await openSession(agent, context, {
+        systemPrompt: "You are operating inside Buzz.",
+      });
+      await agent.prompt(
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "first prompt" }],
+        },
+        context,
+      );
+      await agent.prompt(
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "second prompt" }],
+        },
+        context,
+      );
+
+      expect(server.promptPayloads).toHaveLength(2);
+      const first = JSON.stringify(server.promptPayloads[0]);
+      expect(first).toContain("You are operating inside Buzz.");
+      expect(first.indexOf("You are operating inside Buzz.")).toBeLessThan(
+        first.indexOf("first prompt"),
+      );
+      expect(JSON.stringify(server.promptPayloads[1])).not.toContain(
+        "You are operating inside Buzz.",
+      );
     } finally {
       agent.shutdown();
     }

--- a/test/fixtures/mock-mcp-server.ts
+++ b/test/fixtures/mock-mcp-server.ts
@@ -1,0 +1,91 @@
+/**
+ * Minimal stdio MCP server used by the MCP bridge tests.
+ *
+ * Exposes two tools: `echo`, which returns its argument plus an env var the
+ * client passed at spawn time, and `explode`, which returns an MCP error
+ * result. Hand-rolled rather than built on the MCP server SDK so the test
+ * exercises the wire protocol the adapter's client actually speaks.
+ */
+const TOOLS = [
+  {
+    name: "echo",
+    description: "Echo the given text back.",
+    inputSchema: {
+      type: "object",
+      properties: { text: { type: "string" } },
+      required: ["text"],
+    },
+  },
+  {
+    name: "explode",
+    description: "Always fails.",
+    inputSchema: { type: "object", properties: {} },
+  },
+];
+
+function respond(id: unknown, result: unknown): void {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+}
+
+function handle(message: Record<string, unknown>): void {
+  const { id, method, params } = message as {
+    id?: unknown;
+    method?: string;
+    params?: Record<string, unknown>;
+  };
+  switch (method) {
+    case "initialize":
+      respond(id, {
+        protocolVersion: "2025-06-18",
+        capabilities: { tools: {} },
+        serverInfo: { name: "mock-mcp-server", version: "1.0.0" },
+      });
+      return;
+    case "tools/list":
+      respond(id, { tools: TOOLS });
+      return;
+    case "tools/call": {
+      const name = params?.name;
+      const args = (params?.arguments ?? {}) as Record<string, unknown>;
+      if (name === "explode") {
+        respond(id, {
+          content: [{ type: "text", text: "tool blew up" }],
+          isError: true,
+        });
+        return;
+      }
+      respond(id, {
+        content: [
+          {
+            type: "text",
+            text: `echo:${String(args.text)}:${process.env.MOCK_MCP_TOKEN ?? ""}`,
+          },
+        ],
+      });
+      return;
+    }
+    default:
+      // Notifications (no id) need no reply; unknown requests get an error.
+      if (id !== undefined) {
+        process.stdout.write(
+          `${JSON.stringify({
+            jsonrpc: "2.0",
+            id,
+            error: { code: -32601, message: `Unknown method: ${method}` },
+          })}\n`,
+        );
+      }
+  }
+}
+
+let buffer = "";
+process.stdin.on("data", (chunk: Buffer) => {
+  buffer += chunk.toString("utf8");
+  let newline = buffer.indexOf("\n");
+  while (newline !== -1) {
+    const line = buffer.slice(0, newline).trim();
+    buffer = buffer.slice(newline + 1);
+    if (line.length > 0) handle(JSON.parse(line) as Record<string, unknown>);
+    newline = buffer.indexOf("\n");
+  }
+});

--- a/test/mcp-tools.test.ts
+++ b/test/mcp-tools.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import type { McpServer } from "@agentclientprotocol/sdk";
+import { connectMcpServers } from "../src/mcp-tools.js";
+
+const FIXTURE = new URL("./fixtures/mock-mcp-server.ts", import.meta.url)
+  .pathname;
+
+function stdioServer(name = "buzz"): McpServer {
+  return {
+    name,
+    command: process.execPath,
+    args: [FIXTURE],
+    env: [{ name: "MOCK_MCP_TOKEN", value: "from-client" }],
+  } as McpServer;
+}
+
+describe("MCP bridge", () => {
+  test("exposes namespaced tools from a stdio server", async () => {
+    const bridge = await connectMcpServers([stdioServer()]);
+    try {
+      expect(bridge.tools.map((tool) => tool.name)).toEqual([
+        "mcp__buzz__echo",
+        "mcp__buzz__explode",
+      ]);
+      const echo = bridge.tools[0];
+      expect(echo?.description).toBe("Echo the given text back.");
+      expect(echo?.parameters).toMatchObject({
+        type: "object",
+        properties: { text: { type: "string" } },
+      });
+    } finally {
+      await bridge.close();
+    }
+  });
+
+  test("proxies tool calls, including the env the client supplied", async () => {
+    const bridge = await connectMcpServers([stdioServer()]);
+    try {
+      const echo = bridge.tools.find((tool) => tool.name === "mcp__buzz__echo");
+      const result = await echo?.execute("call-1", { text: "hello" });
+      expect(result?.content).toEqual([
+        { type: "text", text: "echo:hello:from-client" },
+      ]);
+    } finally {
+      await bridge.close();
+    }
+  });
+
+  test("surfaces MCP error results as tool failures", async () => {
+    const bridge = await connectMcpServers([stdioServer()]);
+    try {
+      const explode = bridge.tools.find(
+        (tool) => tool.name === "mcp__buzz__explode",
+      );
+      expect(explode?.execute("call-2", {})).rejects.toThrow("tool blew up");
+    } finally {
+      await bridge.close();
+    }
+  });
+
+  test("namespaces per server so identical tool names do not collide", async () => {
+    const bridge = await connectMcpServers([
+      stdioServer("one"),
+      stdioServer("two"),
+    ]);
+    try {
+      expect(bridge.tools.map((tool) => tool.name)).toEqual([
+        "mcp__one__echo",
+        "mcp__one__explode",
+        "mcp__two__echo",
+        "mcp__two__explode",
+      ]);
+    } finally {
+      await bridge.close();
+    }
+  });
+
+  test("skips a server that cannot start instead of failing the session", async () => {
+    const logs: string[] = [];
+    const bridge = await connectMcpServers(
+      [
+        {
+          name: "broken",
+          command: "/nonexistent/mcp-server",
+          args: [],
+          env: [],
+        } as McpServer,
+        stdioServer(),
+      ],
+      { log: (message) => logs.push(message) },
+    );
+    try {
+      expect(bridge.tools.map((tool) => tool.name)).toEqual([
+        "mcp__buzz__echo",
+        "mcp__buzz__explode",
+      ]);
+      expect(logs.some((line) => line.includes('"broken" unavailable'))).toBe(
+        true,
+      );
+    } finally {
+      await bridge.close();
+    }
+  });
+
+  test("skips non-stdio transports with a warning", async () => {
+    const logs: string[] = [];
+    const bridge = await connectMcpServers(
+      [
+        {
+          type: "http",
+          name: "remote",
+          url: "https://example.test/mcp",
+          headers: [],
+        } as unknown as McpServer,
+      ],
+      { log: (message) => logs.push(message) },
+    );
+    expect(bridge.tools).toEqual([]);
+    expect(
+      logs.some((line) => line.includes("only the stdio transport")),
+    ).toBe(true);
+    await bridge.close();
+  });
+
+  test("no servers means no work and no tools", async () => {
+    const bridge = await connectMcpServers([]);
+    expect(bridge.tools).toEqual([]);
+    await bridge.close();
+  });
+});

--- a/test/model-options.test.ts
+++ b/test/model-options.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import type { ListModelsResult } from "@letta-ai/letta-agent-sdk";
+import { buildModelOption, withCurrentValue } from "../src/model-options.js";
+
+function entry(
+  handle: string,
+  label: string,
+  extra: Partial<ListModelsResult["entries"][number]> = {},
+): ListModelsResult["entries"][number] {
+  return {
+    id: handle.split("/").pop() ?? handle,
+    handle,
+    label,
+    description: "",
+    ...extra,
+  };
+}
+
+function values(option: ReturnType<typeof buildModelOption>): string[] {
+  if (!option || option.type !== "select") return [];
+  return option.options.map((item) => ("value" in item ? item.value : ""));
+}
+
+describe("model config option", () => {
+  test("collapses the reasoning tiers that share one handle", () => {
+    const option = buildModelOption({
+      entries: [
+        entry("anthropic/claude-fable-5", "Fable 5 (low)"),
+        entry("anthropic/claude-fable-5", "Fable 5", { isDefault: true }),
+        entry("openai/gpt-4.1", "GPT-4.1"),
+      ],
+    });
+
+    expect(values(option)).toEqual([
+      "anthropic/claude-fable-5",
+      "openai/gpt-4.1",
+    ]);
+    // The default tier is the one kept, whichever order it arrived in.
+    expect(
+      option?.type === "select" ? option.options[0]?.name : null,
+    ).toBe("Fable 5");
+  });
+
+  test("offers only the handles this user can reach", () => {
+    const option = buildModelOption({
+      entries: [entry("a/one", "One"), entry("b/two", "Two")],
+      availableHandles: ["b/two"],
+    });
+
+    expect(values(option)).toEqual(["b/two"]);
+    expect(option?.type === "select" ? option.currentValue : null).toBe("b/two");
+  });
+
+  test("offers the whole catalog when availability lookup failed", () => {
+    const option = buildModelOption({
+      entries: [entry("a/one", "One"), entry("b/two", "Two")],
+      availableHandles: null,
+    });
+
+    expect(values(option)).toEqual(["a/one", "b/two"]);
+  });
+
+  test("preselects a configured model, by handle or by id", () => {
+    const entries = [
+      entry("a/one", "One", { isDefault: true }),
+      entry("b/two", "Two"),
+    ];
+
+    expect(
+      buildModelOption({ entries }, "b/two")?.type === "select"
+        ? buildModelOption({ entries }, "b/two")?.currentValue
+        : null,
+    ).toBe("b/two");
+    const byId = buildModelOption({ entries }, "two");
+    expect(byId?.type === "select" ? byId.currentValue : null).toBe("b/two");
+  });
+
+  test("falls back to the catalog default, then to the first entry", () => {
+    const withDefault = buildModelOption({
+      entries: [entry("a/one", "One"), entry("b/two", "Two", { isDefault: true })],
+    });
+    expect(withDefault?.type === "select" ? withDefault.currentValue : null).toBe(
+      "b/two",
+    );
+
+    const noDefault = buildModelOption({
+      entries: [entry("a/one", "One"), entry("b/two", "Two")],
+    });
+    expect(noDefault?.type === "select" ? noDefault.currentValue : null).toBe(
+      "a/one",
+    );
+  });
+
+  test("publishes nothing when no model is reachable", () => {
+    expect(buildModelOption({ entries: [] })).toBeNull();
+    expect(
+      buildModelOption({
+        entries: [entry("a/one", "One")],
+        availableHandles: [],
+      }),
+    ).toBeNull();
+  });
+
+  test("withCurrentValue keeps the published option list", () => {
+    const option = buildModelOption({
+      entries: [entry("a/one", "One"), entry("b/two", "Two")],
+    });
+    const switched = withCurrentValue(option!, "b/two");
+
+    expect(switched.type === "select" ? switched.currentValue : null).toBe(
+      "b/two",
+    );
+    expect(values(switched)).toEqual(values(option));
+  });
+});


### PR DESCRIPTION
Makes letta-acp usable as a first-class harness for [Buzz](https://github.com/block/buzz), whose `buzz-acp` harness drives ACP agents over stdio. Companion PR adds `letta` as a preset runtime in Buzz itself.

Buzz passes MCP servers in `session/new`, may send a per-session system prompt, and reads `agentInfo` from `initialize` to identify the adapter. We ignored all three.

## Changes

- **MCP servers** — `session/new` and `session/load` now connect the client's **stdio** MCP servers and register their tools as Letta external tools, namespaced `mcp__<server>__<tool>`. Tool calls proxy through to `tools/call`; servers shut down with the session. A server that fails to start is logged and skipped rather than failing `session/new`; http/sse are skipped with a warning (which is why `initialize` still advertises no `mcpCapabilities`). Zed benefits from this too, not just Buzz.
- **`systemPrompt`** — a client-supplied system prompt on `session/new` is delivered as a framed preamble on the session's first prompt, since Letta agents carry their own persona and the SDK has no per-session system prompt to set.
- **`agentInfo`** — `initialize` reports name + package version. `buzz-acp models` showed `Agent: unknown vunknown` before; it now shows `letta-acp v0.1.4`.
- **Cloud caveat** — cloud agents run their harness in Letta's sandbox, which has no executor for adapter-side tools: both the editor fs tools and MCP tools fail there with `External tool executor not set`. The adapter now warns once at session setup, and the README says which backend to use instead.
- **Docs** — a "Use from Buzz" section with a backend table: the agent answers Buzz by shelling out to the `buzz` CLI, so the CLI has to live wherever the chosen backend runs tools.

## Testing

- `bun run check` (46 tests, typecheck, build). New coverage: the MCP bridge (namespacing, proxying, env pass-through, error results, unreachable server, non-stdio transport) against a fixture stdio MCP server, plus `agentInfo` and one-shot system-prompt delivery.
- Live end-to-end through a real ACP client with an MCP server attached — the model called `mcp__mock__echo` and got its output back — on the `local`, `remote`, and `cloud-oauth` backends. On `cloud` the call fails as described above, which is where the new warning comes from.
- `buzz-acp models --agent-command bun --agent-args src/index.ts` against a locally built `buzz-acp`, on the `local`, `remote`, and `cloud-oauth` backends.