### PR TITLE
feat: add ACP session discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ adapter and delegate to the ACP client.
 | `session/request_permission` (allow once / always / reject) | ✅ |
 | `session/cancel` → `stopReason: cancelled` | ✅ |
 | `session/load` (resume threads with history replay) | ✅ |
+| `session/list` (project-scoped persisted session discovery) | ✅ |
 | Session modes (`session/set_mode`: standard / acceptEdits / unrestricted) | ✅ |
 | Model listing and switching (`configOptions` + `session/set_config_option`) | ✅ |
 | Slash commands (`available_commands_update`, ~30 commands + skills) | ✅ |
@@ -198,9 +199,14 @@ adapter and delegate to the ACP client.
 | Plan updates (`plan` from TodoWrite) | ❌ (planned) |
 
 ACP session ids are Letta conversation ids, so `session/load` works across
-adapter restarts with no local state: the conversation is resumed via the SDK
-and its recent history (up to 200 messages) is replayed as `session/update`
-notifications. Session modes are enforced in the adapter's permission
+adapter restarts when the client already knows the id: the conversation is
+resumed via the SDK and its recent history (up to 200 messages) is replayed as
+`session/update` notifications. For discovery, the adapter records the working
+directory of successful `session/new` and `session/load` calls under
+`~/.letta/letta-acp/sessions/`. `session/list` combines those project-scoped
+records with live conversation titles and timestamps from the configured Letta
+agent; unrelated conversations are not assigned an inferred project. Session
+modes are enforced in the adapter's permission
 callback — the harness always runs in `standard` mode so every approval routes
 through the adapter, which is what makes live mode switching possible;
 `acceptEdits` auto-allows file-edit tools, `unrestricted` auto-allows

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -6,6 +6,8 @@ import {
   type InitializeResponse,
   type LoadSessionRequest,
   type LoadSessionResponse,
+  type ListSessionsRequest,
+  type ListSessionsResponse,
   methods,
   type NewSessionRequest,
   type NewSessionResponse,
@@ -25,6 +27,7 @@ import {
   type CanUseToolResponse,
   LettaAgentClient,
   type LettaCodeSession,
+  type LettaConversation,
   type MessageContentItem,
   type PermissionMode,
   type SDKMessage,
@@ -38,6 +41,7 @@ import {
 } from "./editor-tools.js";
 import { historyToUpdates } from "./history-replay.js";
 import { withAcpRequestTimeout } from "./request-timeout.js";
+import { SessionRegistry } from "./session-registry.js";
 import {
   isSessionModeId,
   modeAutoAllows,
@@ -89,6 +93,8 @@ interface AcpSessionState {
 
 /** Max history messages replayed on session/load. */
 const LOAD_HISTORY_LIMIT = 200;
+/** Number of project sessions returned in one session/list page. */
+const SESSION_LIST_PAGE_SIZE = 50;
 
 /**
  * Liveness bound for permission requests raised outside a prompt turn.
@@ -137,6 +143,7 @@ export class LettaAcpAgent {
   private readonly client: LettaAgentClient;
   private readonly outOfTurnPermissionTimeoutMs: number;
   private readonly prematureResultGraceMs: number;
+  private readonly sessionRegistry: SessionRegistry;
   private readonly sessions = new Map<string, AcpSessionState>();
   private agentIdPromise: Promise<string> | null = null;
   private clientFsCaps: EditorFsCapabilities = {
@@ -147,6 +154,10 @@ export class LettaAcpAgent {
   constructor(config: LettaAcpConfig) {
     this.config = config;
     this.client = new LettaAgentClient(config.clientOptions);
+    this.sessionRegistry = new SessionRegistry(
+      config.sessionRegistryDir ?? null,
+      config.sessionRegistryScope ?? config.clientOptions.backend ?? "local",
+    );
     this.outOfTurnPermissionTimeoutMs =
       config.outOfTurnPermissionTimeoutMs ??
       DEFAULT_OUT_OF_TURN_PERMISSION_TIMEOUT_MS;
@@ -169,6 +180,7 @@ export class LettaAcpAgent {
       protocolVersion,
       agentCapabilities: {
         loadSession: true,
+        sessionCapabilities: { list: {} },
         promptCapabilities: {
           image: true,
           embeddedContext: true,
@@ -192,6 +204,7 @@ export class LettaAcpAgent {
       agentId,
       clientContext: cx,
     });
+    await this.rememberSession(agentId, sessionId, params.cwd);
     log(`session ${sessionId} -> agent ${agentId} (cwd: ${params.cwd})`);
     this.announceCommands(sessionId, cx);
     return {
@@ -219,6 +232,7 @@ export class LettaAcpAgent {
       agentId: null,
       clientContext: cx,
     });
+    await this.rememberSession(state.session.agentId, sessionId, params.cwd);
     const history = await state.session.listMessages({
       order: "desc",
       limit: LOAD_HISTORY_LIMIT,
@@ -238,6 +252,76 @@ export class LettaAcpAgent {
       modes: sessionModeState(state.modeId),
       configOptions: await this.modelConfigOptions(state),
     };
+  }
+
+  async listSessions(params: ListSessionsRequest): Promise<ListSessionsResponse> {
+    const agentId = await this.ensureAgent();
+    const records = await this.sessionRegistry.list(agentId, params.cwd);
+    if (records.length === 0) return { sessions: [] };
+
+    let start = 0;
+    if (params.cursor) {
+      const previous = records.findIndex((record) => record.sessionId === params.cursor);
+      if (previous < 0) throw new Error("Invalid session/list cursor");
+      start = previous + 1;
+    }
+
+    const sessions: ListSessionsResponse["sessions"] = [];
+    let scanned = start;
+    while (scanned < records.length && sessions.length < SESSION_LIST_PAGE_SIZE) {
+      const record = records[scanned++]!;
+      let conversation: LettaConversation;
+      try {
+        conversation = await this.client.conversations.retrieve(record.sessionId);
+      } catch (error) {
+        // A deleted conversation is indistinguishable here from a transient
+        // management failure. Omit it for this response but retain the local
+        // record so an outage cannot erase discoverability permanently.
+        log(`cannot resolve listed session ${record.sessionId}: ${String(error)}`);
+        continue;
+      }
+      if (conversation.agent_id !== agentId || conversation.archived === true) {
+        await this.sessionRegistry.remove(record.sessionId);
+        continue;
+      }
+      const title = sessionTitle(conversation);
+      const updatedAt =
+        conversation.last_message_at ??
+        conversation.updated_at ??
+        conversation.created_at ??
+        record.recordedAt;
+      sessions.push({
+        sessionId: record.sessionId,
+        cwd: record.cwd,
+        ...(title ? { title } : {}),
+        ...(updatedAt ? { updatedAt } : {}),
+      });
+    }
+
+    return {
+      sessions,
+      ...(scanned < records.length && sessions.length > 0
+        ? { nextCursor: records[scanned - 1]!.sessionId }
+        : {}),
+    };
+  }
+
+  private async rememberSession(
+    agentId: string | null | undefined,
+    sessionId: string,
+    cwd: string,
+  ): Promise<void> {
+    if (!agentId) {
+      log(`cannot record session ${sessionId}: runtime did not report an agent id`);
+      return;
+    }
+    try {
+      await this.sessionRegistry.record(agentId, sessionId, cwd);
+    } catch (error) {
+      // Session creation/loading already succeeded. Do not turn a local metadata
+      // write failure into a retry that creates a duplicate conversation.
+      log(`failed to record session ${sessionId}: ${String(error)}`);
+    }
   }
 
   private async modelConfigOptions(
@@ -1028,6 +1112,14 @@ export class LettaAcpAgent {
     );
     return agentId;
   }
+}
+
+function sessionTitle(conversation: LettaConversation): string | undefined {
+  const source = conversation.summary ?? conversation.description;
+  if (!source) return undefined;
+  const title = source.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim();
+  if (!title) return undefined;
+  return title.length <= 256 ? title : `${title.slice(0, 255)}…`;
 }
 
 /** Awaits `pending`, or resolves null when the deadline expires first. */

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type {
   LettaCodeClientOptions,
   PermissionMode,
@@ -12,6 +14,10 @@ export interface LettaAcpConfig {
   model?: string;
   /** Letta permission mode; tool approvals are forwarded to the ACP client. */
   permissionMode: PermissionMode;
+  /** Directory for controller-owned ACP session metadata; null keeps it in memory. */
+  sessionRegistryDir?: string | null;
+  /** Separates records belonging to different Letta backends. */
+  sessionRegistryScope?: string;
   /**
    * Deadline for permission requests raised outside a prompt turn, where the
    * ACP client has no obligation to answer. Defaults to five minutes.
@@ -38,17 +44,21 @@ export function configFromEnv(
   const backend = env.LETTA_ACP_BACKEND ?? "local";
 
   let clientOptions: LettaCodeClientOptions;
+  let sessionRegistryScope = backend;
   switch (backend) {
     case "local":
       clientOptions = { backend: "local" };
       break;
-    case "remote":
+    case "remote": {
+      const url = env.LETTA_APP_SERVER_URL ?? "ws://127.0.0.1:4500";
       clientOptions = {
         backend: "remote",
-        url: env.LETTA_APP_SERVER_URL ?? "ws://127.0.0.1:4500",
+        url,
         authToken: env.LETTA_APP_SERVER_TOKEN,
       };
+      sessionRegistryScope = `remote:${url}`;
       break;
+    }
     case "cloud": {
       const apiKey = env.LETTA_API_KEY;
       if (!apiKey) {
@@ -61,6 +71,7 @@ export function configFromEnv(
       break;
     }
     case "cloud-oauth":
+      sessionRegistryScope = "cloud";
       // Cloud agents authenticated through the letta-code harness rather than
       // an explicit API key: the SDK spawns a local app-server pointed at
       // Letta Cloud, and that harness resolves credentials the same way the
@@ -90,5 +101,8 @@ export function configFromEnv(
     agentId: env.LETTA_AGENT_ID,
     model: env.LETTA_ACP_MODEL,
     permissionMode: permissionMode as PermissionMode,
+    sessionRegistryDir:
+      env.LETTA_ACP_STATE_DIR ?? join(homedir(), ".letta", "letta-acp", "sessions"),
+    sessionRegistryScope,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,9 @@ const connection = await acp
   .onRequest(acp.methods.agent.session.load, (ctx) =>
     agent.loadSession(ctx.params, ctx.client),
   )
+  .onRequest(acp.methods.agent.session.list, (ctx) =>
+    agent.listSessions(ctx.params),
+  )
   .onRequest(acp.methods.agent.session.setMode, (ctx) =>
     agent.setSessionMode(ctx.params, ctx.client),
   )

--- a/src/session-registry.ts
+++ b/src/session-registry.ts
@@ -16,6 +16,7 @@ export interface SessionRegistryRecord {
  */
 export class SessionRegistry {
   private readonly records = new Map<string, SessionRegistryRecord>();
+  private readonly pendingWrites = new Map<string, Promise<void>>();
   private readonly directory: string | null;
 
   constructor(rootDirectory: string | null, scope: string) {
@@ -36,11 +37,22 @@ export class SessionRegistry {
     this.records.set(sessionId, record);
     if (!this.directory) return;
 
-    await mkdir(this.directory, { recursive: true, mode: 0o700 });
-    const destination = this.pathFor(sessionId);
-    const temporary = `${destination}.${process.pid}.${randomUUID()}.tmp`;
-    await writeFile(temporary, `${JSON.stringify(record)}\n`, { mode: 0o600 });
-    await rename(temporary, destination);
+    const previous = this.pendingWrites.get(sessionId) ?? Promise.resolve();
+    const write = previous.catch(() => {}).then(async () => {
+      await mkdir(this.directory!, { recursive: true, mode: 0o700 });
+      const destination = this.pathFor(sessionId);
+      const temporary = `${destination}.${process.pid}.${randomUUID()}.tmp`;
+      await writeFile(temporary, `${JSON.stringify(record)}\n`, { mode: 0o600 });
+      await rename(temporary, destination);
+    });
+    this.pendingWrites.set(sessionId, write);
+    try {
+      await write;
+    } finally {
+      if (this.pendingWrites.get(sessionId) === write) {
+        this.pendingWrites.delete(sessionId);
+      }
+    }
   }
 
   async list(agentId: string, cwd?: string | null): Promise<SessionRegistryRecord[]> {
@@ -75,19 +87,42 @@ export class SessionRegistry {
       throw error;
     }
 
-    await Promise.all(
-      entries
-        .filter((entry) => entry.endsWith(".json"))
-        .map(async (entry) => {
-          try {
-            const raw = await readFile(resolve(this.directory!, entry), "utf8");
-            const record = parseRecord(JSON.parse(raw));
-            if (record) this.records.set(record.sessionId, record);
-          } catch {
-            // Ignore partial or corrupt records; a later successful open rewrites them.
-          }
-        }),
+    const recordFiles = entries.filter((entry) => entry.endsWith(".json"));
+    const presentSessionIds = new Set(
+      recordFiles.flatMap((entry) => {
+        try {
+          return [decodeURIComponent(entry.slice(0, -".json".length))];
+        } catch {
+          return [];
+        }
+      }),
     );
+    const diskRecords = await Promise.all(
+      recordFiles.map(async (entry) => {
+        try {
+          const raw = await readFile(resolve(this.directory!, entry), "utf8");
+          return parseRecord(JSON.parse(raw));
+        } catch {
+          // Ignore partial or corrupt records; a later successful open rewrites them.
+          return null;
+        }
+      }),
+    );
+
+    for (const record of diskRecords) {
+      if (!record) continue;
+      const current = this.records.get(record.sessionId);
+      if (!current || Date.parse(record.recordedAt) > Date.parse(current.recordedAt)) {
+        this.records.set(record.sessionId, record);
+      }
+    }
+    // Another adapter process may remove a record. Mirror that deletion without
+    // pruning a same-process record whose serialized write is still pending.
+    for (const sessionId of this.records.keys()) {
+      if (!presentSessionIds.has(sessionId) && !this.pendingWrites.has(sessionId)) {
+        this.records.delete(sessionId);
+      }
+    }
   }
 
   private pathFor(sessionId: string): string {

--- a/src/session-registry.ts
+++ b/src/session-registry.ts
@@ -1,0 +1,125 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
+
+export interface SessionRegistryRecord {
+  agentId: string;
+  sessionId: string;
+  cwd: string;
+  recordedAt: string;
+}
+
+/**
+ * Adapter-owned persistence for ACP runtime metadata that Letta conversations
+ * do not store. One file per conversation keeps concurrent editor processes
+ * from overwriting unrelated sessions.
+ */
+export class SessionRegistry {
+  private readonly records = new Map<string, SessionRegistryRecord>();
+  private readonly directory: string | null;
+
+  constructor(rootDirectory: string | null, scope: string) {
+    const namespace = createHash("sha256").update(scope).digest("hex").slice(0, 20);
+    this.directory = rootDirectory ? resolve(rootDirectory, namespace) : null;
+  }
+
+  async record(agentId: string, sessionId: string, cwd: string): Promise<void> {
+    if (!isAbsolute(cwd)) {
+      throw new Error(`Cannot record ACP session ${sessionId}: cwd must be absolute`);
+    }
+    const record: SessionRegistryRecord = {
+      agentId,
+      sessionId,
+      cwd: resolve(cwd),
+      recordedAt: new Date().toISOString(),
+    };
+    this.records.set(sessionId, record);
+    if (!this.directory) return;
+
+    await mkdir(this.directory, { recursive: true });
+    const destination = this.pathFor(sessionId);
+    const temporary = `${destination}.${process.pid}.${randomUUID()}.tmp`;
+    await writeFile(temporary, `${JSON.stringify(record)}\n`, { mode: 0o600 });
+    await rename(temporary, destination);
+  }
+
+  async list(agentId: string, cwd?: string | null): Promise<SessionRegistryRecord[]> {
+    await this.load();
+    const normalizedCwd = cwd ? resolve(cwd) : null;
+    return [...this.records.values()]
+      .filter(
+        (record) =>
+          record.agentId === agentId &&
+          (normalizedCwd === null || record.cwd === normalizedCwd),
+      )
+      .sort(
+        (left, right) =>
+          Date.parse(right.recordedAt) - Date.parse(left.recordedAt) ||
+          left.sessionId.localeCompare(right.sessionId),
+      );
+  }
+
+  async remove(sessionId: string): Promise<void> {
+    this.records.delete(sessionId);
+    if (!this.directory) return;
+    await rm(this.pathFor(sessionId), { force: true });
+  }
+
+  private async load(): Promise<void> {
+    if (!this.directory) return;
+    let entries: string[];
+    try {
+      entries = await readdir(this.directory);
+    } catch (error) {
+      if (isMissing(error)) return;
+      throw error;
+    }
+
+    await Promise.all(
+      entries
+        .filter((entry) => entry.endsWith(".json"))
+        .map(async (entry) => {
+          try {
+            const raw = await readFile(resolve(this.directory!, entry), "utf8");
+            const record = parseRecord(JSON.parse(raw));
+            if (record) this.records.set(record.sessionId, record);
+          } catch {
+            // Ignore partial or corrupt records; a later successful open rewrites them.
+          }
+        }),
+    );
+  }
+
+  private pathFor(sessionId: string): string {
+    return resolve(this.directory!, `${encodeURIComponent(sessionId)}.json`);
+  }
+}
+
+function parseRecord(value: unknown): SessionRegistryRecord | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.agentId !== "string" ||
+    typeof record.sessionId !== "string" ||
+    typeof record.cwd !== "string" ||
+    !isAbsolute(record.cwd) ||
+    typeof record.recordedAt !== "string" ||
+    !Number.isFinite(Date.parse(record.recordedAt))
+  ) {
+    return null;
+  }
+  return {
+    agentId: record.agentId,
+    sessionId: record.sessionId,
+    cwd: resolve(record.cwd),
+    recordedAt: record.recordedAt,
+  };
+}
+
+function isMissing(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}

--- a/test/acpx-client.test.ts
+++ b/test/acpx-client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { SessionRegistry } from "../src/session-registry.js";
 
 interface RuntimeScope {
   agent_id: string;
@@ -52,6 +53,14 @@ function startFakeAppServer() {
             }));
             return;
           }
+          case "conversation_retrieve":
+            socket.send(JSON.stringify({
+              type: "conversation_retrieve_response",
+              request_id: requiredString(message.request_id),
+              success: true,
+              conversation: TEST_CONVERSATION,
+            }));
+            return;
           case "conversation_messages_list":
             socket.send(JSON.stringify({
               type: "conversation_messages_list_response",
@@ -120,6 +129,14 @@ const TEST_RUNTIME: RuntimeScope = {
   conversation_id: "conv-acpx-test",
 };
 
+const TEST_CONVERSATION = {
+  id: TEST_RUNTIME.conversation_id,
+  agent_id: TEST_RUNTIME.agent_id,
+  summary: "ACP client compatibility session",
+  archived: false,
+  updated_at: "2026-07-29T12:00:00.000Z",
+};
+
 function sendDelta(
   socket: { send(data: string): unknown },
   delta: WireMessage,
@@ -138,10 +155,23 @@ function requiredString(value: unknown): string {
   return value;
 }
 
-async function runAcpx(format: "json" | "quiet") {
+async function runAcpx(
+  format: "json" | "quiet",
+  command: string[] = ["exec", "Exercise the ACP tool lifecycle."],
+  seedSession = false,
+) {
   const home = mkdtempSync(join(tmpdir(), "letta-acp-acpx-"));
   tempDirs.push(home);
   const appServerUrl = startFakeAppServer();
+  const cwd = join(import.meta.dir, "..");
+  if (seedSession) {
+    const registry = new SessionRegistry(
+      join(home, ".letta", "letta-acp", "sessions"),
+      `remote:${appServerUrl}`,
+    );
+    await registry.record(TEST_RUNTIME.agent_id, TEST_RUNTIME.conversation_id, cwd);
+  }
+
   const acpxPath = join(import.meta.dir, "..", "node_modules", ".bin", "acpx");
   const agentPath = join(import.meta.dir, "..", "src", "index.ts");
   const child = Bun.spawn(
@@ -153,11 +183,10 @@ async function runAcpx(format: "json" | "quiet") {
       format,
       "--timeout",
       "5",
-      "exec",
-      "Exercise the ACP tool lifecycle.",
+      ...command,
     ],
     {
-      cwd: join(import.meta.dir, ".."),
+      cwd,
       env: {
         ...process.env,
         HOME: home,
@@ -178,13 +207,38 @@ async function runAcpx(format: "json" | "quiet") {
   if (exitCode !== 0) {
     throw new Error(`acpx exited ${exitCode}:\n${stderr}\n${stdout}`);
   }
-  return { stdout, stderr };
+  return { stdout, stderr, home, appServerUrl, cwd };
 }
 
 describe("acpx client compatibility", () => {
   test("completes a prompt through a real ACP client", async () => {
     const { stdout } = await runAcpx("quiet");
     expect(stdout.trim()).toBe("ACPX_OK");
+  }, 10_000);
+
+  test("records a new ACP session for discovery", async () => {
+    const { home, appServerUrl, cwd } = await runAcpx("quiet");
+    const registry = new SessionRegistry(
+      join(home, ".letta", "letta-acp", "sessions"),
+      `remote:${appServerUrl}`,
+    );
+
+    expect(await registry.list(TEST_RUNTIME.agent_id, cwd)).toEqual([
+      expect.objectContaining({ sessionId: TEST_RUNTIME.conversation_id, cwd }),
+    ]);
+  }, 10_000);
+
+  test("lists project sessions through a real ACP client", async () => {
+    const cwd = join(import.meta.dir, "..");
+    const { stdout } = await runAcpx(
+      "json",
+      ["sessions", "list", "--filter-cwd", cwd],
+      true,
+    );
+
+    expect(stdout).toContain(TEST_RUNTIME.conversation_id);
+    expect(stdout).toContain("ACP client compatibility session");
+    expect(stdout).toContain(cwd);
   }, 10_000);
 
   test("emits a complete tool lifecycle as ACP notifications", async () => {

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -174,10 +174,24 @@ class FakeAppServer {
           memory_directory: "/tmp/letta-acp-memory",
         });
         return;
-      case "conversation_retrieve":
-        this.conversationRetrieveIds.push(
-          requiredString(message.conversation_id, "conversation_retrieve.conversation_id"),
+      case "conversation_retrieve": {
+        const conversationId = requiredString(
+          message.conversation_id,
+          "conversation_retrieve.conversation_id",
         );
+        this.conversationRetrieveIds.push(conversationId);
+        if (conversationId.includes("missing")) {
+          socket.push({
+            type: "conversation_retrieve_response",
+            request_id: requiredString(
+              message.request_id,
+              "conversation_retrieve.request_id",
+            ),
+            success: false,
+            error: "conversation unavailable",
+          });
+          return;
+        }
         socket.push({
           type: "conversation_retrieve_response",
           request_id: requiredString(
@@ -186,11 +200,13 @@ class FakeAppServer {
           ),
           success: true,
           conversation: {
-            id: message.conversation_id,
-            agent_id: "agent-test",
+            id: conversationId,
+            agent_id: conversationId.includes("foreign") ? "agent-other" : "agent-test",
+            archived: conversationId.includes("archived"),
           },
         });
         return;
+      }
       case "conversation_messages_list":
         socket.push({
           type: "conversation_messages_list_response",
@@ -691,6 +707,35 @@ describe("Agent SDK app-server integration", () => {
       expect(second.sessions).toHaveLength(1);
       expect(second.nextCursor).toBeUndefined();
       expect(server.conversationRetrieveIds).toHaveLength(51);
+    } finally {
+      agent.shutdown();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("removes archived and foreign sessions but retains unavailable records", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "letta-acp-list-stale-"));
+    const scope = "stale-test";
+    const registry = new SessionRegistry(directory, scope);
+    const cwd = "/tmp/letta-acp-test";
+    await registry.record("agent-test", "conv-visible", cwd);
+    await registry.record("agent-test", "conv-archived", cwd);
+    await registry.record("agent-test", "conv-foreign", cwd);
+    await registry.record("agent-test", "conv-missing", cwd);
+
+    const server = new FakeAppServer();
+    const agent = createAgent(server, {
+      sessionRegistryDir: directory,
+      sessionRegistryScope: scope,
+    });
+    try {
+      const result = await agent.listSessions({ cwd });
+      expect(result.sessions.map((session) => session.sessionId)).toEqual([
+        "conv-visible",
+      ]);
+      expect(
+        (await registry.list("agent-test", cwd)).map((record) => record.sessionId).sort(),
+      ).toEqual(["conv-missing", "conv-visible"]);
     } finally {
       agent.shutdown();
       await rm(directory, { recursive: true, force: true });

--- a/test/session-registry.test.ts
+++ b/test/session-registry.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionRegistry } from "../src/session-registry.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "letta-acp-sessions-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+describe("SessionRegistry", () => {
+  test("persists project-scoped sessions across adapter processes", async () => {
+    const directory = await temporaryDirectory();
+    const first = new SessionRegistry(directory, "cloud");
+    await first.record("agent-1", "conv-one", "/workspace/one");
+    await first.record("agent-1", "conv-two", "/workspace/two");
+    await first.record("agent-2", "conv-other-agent", "/workspace/one");
+
+    const restarted = new SessionRegistry(directory, "cloud");
+    expect(await restarted.list("agent-1", "/workspace/one")).toEqual([
+      expect.objectContaining({
+        agentId: "agent-1",
+        sessionId: "conv-one",
+        cwd: "/workspace/one",
+      }),
+    ]);
+  });
+
+  test("isolates records from different backends", async () => {
+    const directory = await temporaryDirectory();
+    await new SessionRegistry(directory, "cloud").record(
+      "agent-1",
+      "conv-cloud",
+      "/workspace",
+    );
+
+    expect(
+      await new SessionRegistry(directory, "local").list("agent-1", "/workspace"),
+    ).toEqual([]);
+  });
+
+  test("moves a conversation when it is loaded from a different cwd", async () => {
+    const directory = await temporaryDirectory();
+    const registry = new SessionRegistry(directory, "cloud");
+    await registry.record("agent-1", "conv-one", "/workspace/one");
+    await registry.record("agent-1", "conv-one", "/workspace/two");
+
+    expect(await registry.list("agent-1", "/workspace/one")).toEqual([]);
+    expect(await registry.list("agent-1", "/workspace/two")).toHaveLength(1);
+  });
+
+  test("rejects relative working directories", async () => {
+    const registry = new SessionRegistry(null, "test");
+    await expect(registry.record("agent-1", "conv-one", "relative/path")).rejects.toThrow(
+      "cwd must be absolute",
+    );
+  });
+});

--- a/test/session-registry.test.ts
+++ b/test/session-registry.test.ts
@@ -51,6 +51,18 @@ describe("SessionRegistry", () => {
     ).toEqual([]);
   });
 
+  test("observes records removed by another adapter process", async () => {
+    const directory = await temporaryDirectory();
+    const first = new SessionRegistry(directory, "cloud");
+    const second = new SessionRegistry(directory, "cloud");
+    await first.record("agent-1", "conv-one", "/workspace");
+    expect(await second.list("agent-1", "/workspace")).toHaveLength(1);
+
+    await first.remove("conv-one");
+
+    expect(await second.list("agent-1", "/workspace")).toEqual([]);
+  });
+
   test("moves a conversation when it is loaded from a different cwd", async () => {
     const directory = await temporaryDirectory();
     const registry = new SessionRegistry(directory, "cloud");


### PR DESCRIPTION
## Summary

- advertise and implement stable ACP `session/list` support
- persist adapter-owned `{ agentId, conversationId, cwd }` metadata so clients can discover project sessions across adapter restarts
- resolve live Letta conversation titles and timestamps without assigning unrelated conversations an inferred working directory
- reconcile concurrent adapter writes/deletions and bound each discovery page to 50 conversation lookups

## Behavior

`session/new` and successful `session/load` calls record their project association under `~/.letta/letta-acp/sessions/`. Clients such as acpx and Zed can then list sessions for the current working directory and resume them through the existing history-replay path.

Arbitrary Letta conversations created outside ACP are intentionally not backfilled because they have no trustworthy historical `cwd`. Archived or wrong-agent conversations are removed from the registry. A temporarily unavailable conversation is omitted without deleting its local record.

Closes #15.

## Validation

- [x] `bun run check` — 59 tests, typecheck, and build
- [x] real `acpx` stdio test proves a new session is recorded
- [x] real `acpx sessions list` test proves project session discovery through the external client boundary
- [x] persistence, backend isolation, cwd filtering, reassignment, concurrent deletion, and invalid cwd coverage
- [x] pagination is bounded to 50 registry records per request
- [x] archived/wrong-agent records are pruned while transient failures are retained

👾 Generated with [Letta Code](https://letta.com)