### PR TITLE
feat: render Bash output as ACP terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ history ≈ `/resume`).
   `session/update` notifications.
 - When the client advertises `_meta.terminal_output`, Bash calls use ACP terminal
   content plus `terminal_info`, `terminal_output`, and `terminal_exit` updates.
-  Other clients receive a text fallback capped at 16 KiB for display, while
-  `rawOutput` retains the complete result.
+  Terminal and text displays retain the first and last 12 lines and are capped
+  at 16 KiB, while `rawOutput` retains the complete result.
 - Tool approvals: the SDK's `canUseTool` callback is forwarded as an ACP
   `session/request_permission` request. One Letta-specific wrinkle: the
   app-server transport ends the turn with a recoverable `approval_conflict`

--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ history ≈ `/resume`).
   `session/update` notifications.
 - When the client advertises `_meta.terminal_output`, Bash calls use ACP terminal
   content plus `terminal_info`, `terminal_output`, and `terminal_exit` updates.
-  Terminal and text displays retain the first and last 12 lines and are capped
-  at 16 KiB, while `rawOutput` retains the complete result.
+  Zed controls whether terminal cards start expanded or collapsed; the adapter
+  sends the complete output and retains it in `rawOutput`.
 - Tool approvals: the SDK's `canUseTool` callback is forwarded as an ACP
   `session/request_permission` request. One Letta-specific wrinkle: the
   app-server transport ends the turn with a recoverable `approval_conflict`

--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ adapter and delegate to the ACP client.
 | Model listing and switching (`configOptions` + `session/set_config_option`) | ✅ |
 | Slash commands (`available_commands_update`, ~30 commands + skills) | ✅ |
 | Client fs delegation (`fs/read_text_file`, `fs/write_text_file`) | ✅ via external tools |
-| Client terminal delegation (`terminal/*`) | ❌ (planned) |
+| Native Bash result rendering (`_meta.terminal_output`) | ✅ when supported by the client |
+| Client-side command execution (`terminal/*`) | ❌ (planned) |
 | Plan updates (`plan` from TodoWrite) | ❌ (planned) |
 
 ACP session ids are Letta conversation ids, so `session/load` works across
@@ -237,6 +238,10 @@ history ≈ `/resume`).
 - `session/prompt` sends the message and pumps `session.stream()`, translating
   SDK messages (`assistant`, `reasoning`, `tool_call`, `tool_result`) into
   `session/update` notifications.
+- When the client advertises `_meta.terminal_output`, Bash calls use ACP terminal
+  content plus `terminal_info`, `terminal_output`, and `terminal_exit` updates.
+  Other clients receive a text fallback capped at 16 KiB for display, while
+  `rawOutput` retains the complete result.
 - Tool approvals: the SDK's `canUseTool` callback is forwarded as an ACP
   `session/request_permission` request. One Letta-specific wrinkle: the
   app-server transport ends the turn with a recoverable `approval_conflict`

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -847,7 +847,7 @@ export class LettaAcpAgent {
               _meta: {
                 terminal_output: {
                   terminal_id: message.toolCallId,
-                  data: message.content,
+                  data: boundedToolOutput(message.content),
                 },
               },
             },

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -49,7 +49,6 @@ import {
 } from "./slash-commands.js";
 import {
   accumulateToolInput,
-  boundedToolOutput,
   isTerminalOutputTool,
   parseToolOutput,
   type ToolCallInputState,
@@ -847,7 +846,7 @@ export class LettaAcpAgent {
               _meta: {
                 terminal_output: {
                   terminal_id: message.toolCallId,
-                  data: boundedToolOutput(message.content),
+                  data: message.content,
                 },
               },
             },
@@ -878,10 +877,7 @@ export class LettaAcpAgent {
                         type: "content" as const,
                         content: {
                           type: "text" as const,
-                          text:
-                            toolCall && isTerminalOutputTool(toolCall.toolName)
-                              ? boundedToolOutput(message.content)
-                              : message.content,
+                          text: message.content,
                         },
                       },
                     ],

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -49,6 +49,8 @@ import {
 } from "./slash-commands.js";
 import {
   accumulateToolInput,
+  boundedToolOutput,
+  isTerminalOutputTool,
   parseToolOutput,
   type ToolCallInputState,
   toolDiffContent,
@@ -64,6 +66,8 @@ interface StreamedToolCall {
   input: ToolCallInputState;
   /** Whether the ACP card already contains a native diff. */
   hasDiff: boolean;
+  /** Whether terminal_info has created a native terminal for this call. */
+  hasTerminal: boolean;
 }
 
 interface AcpSessionState {
@@ -139,6 +143,7 @@ export class LettaAcpAgent {
   private readonly prematureResultGraceMs: number;
   private readonly sessions = new Map<string, AcpSessionState>();
   private agentIdPromise: Promise<string> | null = null;
+  private supportsTerminalOutput = false;
   private clientFsCaps: EditorFsCapabilities = {
     readTextFile: false,
     writeTextFile: false,
@@ -156,6 +161,8 @@ export class LettaAcpAgent {
 
   async initialize(params: InitializeRequest): Promise<InitializeResponse> {
     const fs = params.clientCapabilities?.fs;
+    this.supportsTerminalOutput =
+      params.clientCapabilities?._meta?.terminal_output === true;
     this.clientFsCaps = {
       readTextFile: fs?.readTextFile === true,
       writeTextFile: fs?.writeTextFile === true,
@@ -228,7 +235,10 @@ export class LettaAcpAgent {
         `session ${sessionId} has more than ${LOAD_HISTORY_LIMIT} messages; replaying the most recent ${LOAD_HISTORY_LIMIT}`,
       );
     }
-    const updates = historyToUpdates([...history.messages].reverse());
+    const updates = historyToUpdates([...history.messages].reverse(), {
+      terminalOutput: this.supportsTerminalOutput,
+      cwd: state.cwd,
+    });
     for (const update of updates) {
       await cx.notify(methods.client.session.update, { sessionId, update });
     }
@@ -772,7 +782,15 @@ export class LettaAcpAgent {
         );
         const diffContent = toolDiffContent(toolName, input.input);
         const hasDiff = existing?.hasDiff === true || diffContent.length > 0;
-        state.toolCalls.set(message.toolCallId, { toolName, input, hasDiff });
+        const nativeTerminal =
+          this.supportsTerminalOutput && isTerminalOutputTool(toolName);
+        const addTerminal = nativeTerminal && existing?.hasTerminal !== true;
+        state.toolCalls.set(message.toolCallId, {
+          toolName,
+          input,
+          hasDiff,
+          hasTerminal: existing?.hasTerminal === true || addTerminal,
+        });
         state.lastToolCall = { id: message.toolCallId, name: toolName };
         // Partial JSON has no usable title or locations, so hold the card
         // steady until the arguments parse rather than flickering through
@@ -793,7 +811,19 @@ export class LettaAcpAgent {
             status: "in_progress",
             rawInput: input.input,
             locations: toolLocations(input.input),
-            ...(diffContent.length > 0 ? { content: diffContent } : {}),
+            ...(diffContent.length > 0
+              ? { content: diffContent }
+              : addTerminal
+                ? {
+                    content: [{ type: "terminal" as const, terminalId: message.toolCallId }],
+                    _meta: {
+                      terminal_info: {
+                        terminal_id: message.toolCallId,
+                        cwd: state.cwd,
+                      },
+                    },
+                  }
+                : {}),
           },
         });
         return true;
@@ -805,6 +835,24 @@ export class LettaAcpAgent {
         const locations = toolCall
           ? toolLocations(toolCall.input.input, toolOutputLine(rawOutput))
           : [];
+        const nativeTerminal = toolCall?.hasTerminal === true;
+        if (nativeTerminal) {
+          // Zed creates the display-only terminal from terminal_info on the
+          // initial call, then consumes output and exit as ordered updates.
+          await cx.notify(methods.client.session.update, {
+            sessionId,
+            update: {
+              sessionUpdate: "tool_call_update",
+              toolCallId: message.toolCallId,
+              _meta: {
+                terminal_output: {
+                  terminal_id: message.toolCallId,
+                  data: message.content,
+                },
+              },
+            },
+          });
+        }
         await cx.notify(methods.client.session.update, {
           sessionId,
           update: {
@@ -813,16 +861,32 @@ export class LettaAcpAgent {
             status: message.isError ? "failed" : "completed",
             rawOutput,
             ...(locations.length > 0 ? { locations } : {}),
-            ...(toolCall?.hasDiff !== true || message.isError
+            ...(nativeTerminal
               ? {
-                  content: [
-                    {
-                      type: "content" as const,
-                      content: { type: "text" as const, text: message.content },
+                  _meta: {
+                    terminal_exit: {
+                      terminal_id: message.toolCallId,
+                      exit_code: message.isError ? 1 : 0,
+                      signal: null,
                     },
-                  ],
+                  },
                 }
-              : {}),
+              : toolCall?.hasDiff !== true || message.isError
+                ? {
+                    content: [
+                      {
+                        type: "content" as const,
+                        content: {
+                          type: "text" as const,
+                          text:
+                            toolCall && isTerminalOutputTool(toolCall.toolName)
+                              ? boundedToolOutput(message.content)
+                              : message.content,
+                        },
+                      },
+                    ],
+                  }
+                : {}),
           },
         });
         return true;

--- a/src/history-replay.ts
+++ b/src/history-replay.ts
@@ -130,7 +130,10 @@ export function historyToUpdates(
             sessionUpdate: "tool_call_update",
             toolCallId,
             _meta: {
-              terminal_output: { terminal_id: toolCallId, data: text },
+              terminal_output: {
+                terminal_id: toolCallId,
+                data: boundedToolOutput(text),
+              },
             },
           });
         }

--- a/src/history-replay.ts
+++ b/src/history-replay.ts
@@ -1,5 +1,7 @@
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import {
+  boundedToolOutput,
+  isTerminalOutputTool,
   parseToolOutput,
   toolDiffContent,
   toolKind,
@@ -13,9 +15,13 @@ import {
  * payloads for session/load replay. Tolerant of unknown shapes: anything we
  * can't map is skipped.
  */
-export function historyToUpdates(messages: unknown[]): SessionUpdate[] {
+export function historyToUpdates(
+  messages: unknown[],
+  options: { terminalOutput?: boolean; cwd?: string } = {},
+): SessionUpdate[] {
   const updates: SessionUpdate[] = [];
   const toolInputs = new Map<string, Record<string, unknown>>();
+  const toolNames = new Map<string, string>();
   const diffToolCalls = new Set<string>();
   for (const raw of messages) {
     if (!raw || typeof raw !== "object") continue;
@@ -70,17 +76,32 @@ export function historyToUpdates(messages: unknown[]): SessionUpdate[] {
         const toolName = readString(toolCall, ["name"]) ?? "tool";
         const input = parseArguments(toolCall.arguments);
         const diffContent = toolDiffContent(toolName, input);
+        const nativeTerminal =
+          options.terminalOutput === true && isTerminalOutputTool(toolName);
         toolInputs.set(toolCallId, input);
+        toolNames.set(toolCallId, toolName);
         if (diffContent.length > 0) diffToolCalls.add(toolCallId);
         updates.push({
           sessionUpdate: "tool_call",
           toolCallId,
           title: toolTitle(toolName, input),
           kind: toolKind(toolName),
-          status: "completed",
+          status: nativeTerminal ? "in_progress" : "completed",
           rawInput: input,
           locations: toolLocations(input),
-          ...(diffContent.length > 0 ? { content: diffContent } : {}),
+          ...(diffContent.length > 0
+            ? { content: diffContent }
+            : nativeTerminal
+              ? {
+                  content: [{ type: "terminal", terminalId: toolCallId }],
+                  _meta: {
+                    terminal_info: {
+                      terminal_id: toolCallId,
+                      ...(options.cwd ? { cwd: options.cwd } : {}),
+                    },
+                  },
+                }
+              : {}),
         });
         break;
       }
@@ -92,25 +113,59 @@ export function historyToUpdates(messages: unknown[]): SessionUpdate[] {
         const failed = message.status === "error";
         const rawOutput = text !== undefined ? parseToolOutput(text) : undefined;
         const input = toolInputs.get(toolCallId);
+        const toolName = toolNames.get(toolCallId);
         const hasDiff = diffToolCalls.has(toolCallId);
+        const nativeTerminal =
+          options.terminalOutput === true &&
+          toolName !== undefined &&
+          isTerminalOutputTool(toolName);
         toolInputs.delete(toolCallId);
+        toolNames.delete(toolCallId);
         diffToolCalls.delete(toolCallId);
         const locations = input
           ? toolLocations(input, toolOutputLine(rawOutput))
           : [];
+        if (nativeTerminal && text !== undefined) {
+          updates.push({
+            sessionUpdate: "tool_call_update",
+            toolCallId,
+            _meta: {
+              terminal_output: { terminal_id: toolCallId, data: text },
+            },
+          });
+        }
         updates.push({
           sessionUpdate: "tool_call_update",
           toolCallId,
           status: failed ? "failed" : "completed",
           ...(rawOutput !== undefined ? { rawOutput } : {}),
           ...(locations.length > 0 ? { locations } : {}),
-          ...(text && (!hasDiff || failed)
+          ...(nativeTerminal
             ? {
-                content: [
-                  { type: "content", content: { type: "text", text } },
-                ],
+                _meta: {
+                  terminal_exit: {
+                    terminal_id: toolCallId,
+                    exit_code: failed ? 1 : 0,
+                    signal: null,
+                  },
+                },
               }
-            : {}),
+            : text && (!hasDiff || failed)
+              ? {
+                  content: [
+                    {
+                      type: "content",
+                      content: {
+                        type: "text",
+                        text:
+                          toolName && isTerminalOutputTool(toolName)
+                            ? boundedToolOutput(text)
+                            : text,
+                      },
+                    },
+                  ],
+                }
+              : {}),
         });
         break;
       }

--- a/src/history-replay.ts
+++ b/src/history-replay.ts
@@ -1,6 +1,5 @@
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import {
-  boundedToolOutput,
   isTerminalOutputTool,
   parseToolOutput,
   toolDiffContent,
@@ -130,10 +129,7 @@ export function historyToUpdates(
             sessionUpdate: "tool_call_update",
             toolCallId,
             _meta: {
-              terminal_output: {
-                terminal_id: toolCallId,
-                data: boundedToolOutput(text),
-              },
+              terminal_output: { terminal_id: toolCallId, data: text },
             },
           });
         }
@@ -158,13 +154,7 @@ export function historyToUpdates(
                   content: [
                     {
                       type: "content",
-                      content: {
-                        type: "text",
-                        text:
-                          toolName && isTerminalOutputTool(toolName)
-                            ? boundedToolOutput(text)
-                            : text,
-                      },
+                      content: { type: "text", text },
                     },
                   ],
                 }

--- a/src/tool-info.ts
+++ b/src/tool-info.ts
@@ -128,23 +128,38 @@ export function toolDiffContent(
   return [];
 }
 
-const TOOL_OUTPUT_FALLBACK_BYTES = 16 * 1024;
+const TOOL_OUTPUT_DISPLAY_BYTES = 16 * 1024;
+const TOOL_OUTPUT_DISPLAY_LINES = 24;
 
 export function isTerminalOutputTool(toolName: string): boolean {
   return toolName.toLowerCase() === "bash";
 }
 
 /**
- * Keep generic clients responsive without changing the full rawOutput payload.
- * Native-terminal clients receive the complete output through terminal metadata.
+ * Keep tool cards compact without changing the full rawOutput payload. Preserve
+ * both ends because failures and summaries commonly land at the end of output.
  */
 export function boundedToolOutput(content: string): string {
-  const encoded = Buffer.from(content);
-  if (encoded.byteLength <= TOOL_OUTPUT_FALLBACK_BYTES) return content;
+  const trailingNewline = content.endsWith("\n");
+  const lines = content.split("\n");
+  if (trailingNewline) lines.pop();
+  let display = content;
+  if (lines.length > TOOL_OUTPUT_DISPLAY_LINES) {
+    const side = TOOL_OUTPUT_DISPLAY_LINES / 2;
+    const omitted = lines.length - TOOL_OUTPUT_DISPLAY_LINES;
+    display = `${[
+      ...lines.slice(0, side),
+      `… ${omitted} lines omitted from display …`,
+      ...lines.slice(-side),
+    ].join("\n")}${trailingNewline ? "\n" : ""}`;
+  }
+
+  const encoded = Buffer.from(display);
+  if (encoded.byteLength <= TOOL_OUTPUT_DISPLAY_BYTES) return display;
 
   const marker = "\n\n… output truncated for display …\n\n";
   const markerBytes = Buffer.byteLength(marker);
-  const remaining = TOOL_OUTPUT_FALLBACK_BYTES - markerBytes;
+  const remaining = TOOL_OUTPUT_DISPLAY_BYTES - markerBytes;
   const headBytes = Math.floor(remaining / 2);
   const tailBytes = remaining - headBytes;
   return `${decodeUtf8Boundary(encoded.subarray(0, headBytes), "head")}${marker}${decodeUtf8Boundary(

--- a/src/tool-info.ts
+++ b/src/tool-info.ts
@@ -128,6 +128,44 @@ export function toolDiffContent(
   return [];
 }
 
+const TOOL_OUTPUT_FALLBACK_BYTES = 16 * 1024;
+
+export function isTerminalOutputTool(toolName: string): boolean {
+  return toolName.toLowerCase() === "bash";
+}
+
+/**
+ * Keep generic clients responsive without changing the full rawOutput payload.
+ * Native-terminal clients receive the complete output through terminal metadata.
+ */
+export function boundedToolOutput(content: string): string {
+  const encoded = Buffer.from(content);
+  if (encoded.byteLength <= TOOL_OUTPUT_FALLBACK_BYTES) return content;
+
+  const marker = "\n\n… output truncated for display …\n\n";
+  const markerBytes = Buffer.byteLength(marker);
+  const remaining = TOOL_OUTPUT_FALLBACK_BYTES - markerBytes;
+  const headBytes = Math.floor(remaining / 2);
+  const tailBytes = remaining - headBytes;
+  return `${decodeUtf8Boundary(encoded.subarray(0, headBytes), "head")}${marker}${decodeUtf8Boundary(
+    encoded.subarray(encoded.byteLength - tailBytes),
+    "tail",
+  )}`;
+}
+
+function decodeUtf8Boundary(bytes: Buffer, side: "head" | "tail"): string {
+  for (let offset = 0; offset < Math.min(4, bytes.byteLength); offset += 1) {
+    const candidate =
+      side === "head" ? bytes.subarray(0, bytes.byteLength - offset) : bytes.subarray(offset);
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(candidate);
+    } catch {
+      // The byte slice may start or end inside a multibyte codepoint.
+    }
+  }
+  return "";
+}
+
 /** Parse tool output for ACP rawOutput while preserving non-JSON text. */
 export function parseToolOutput(content: string): unknown {
   try {
@@ -142,6 +180,12 @@ export function toolTitle(
   toolName: string,
   toolInput: Record<string, unknown>,
 ): string {
+  if (isTerminalOutputTool(toolName)) {
+    const command = firstString(toolInput, ["command"]);
+    // Keep the executable command intact: shortening or replacing it with a
+    // friendly description can hide the operation a user is approving.
+    return command ?? toolName;
+  }
   const detail =
     firstString(toolInput, [
       "file_path",

--- a/src/tool-info.ts
+++ b/src/tool-info.ts
@@ -128,57 +128,8 @@ export function toolDiffContent(
   return [];
 }
 
-const TOOL_OUTPUT_DISPLAY_BYTES = 16 * 1024;
-const TOOL_OUTPUT_DISPLAY_LINES = 24;
-
 export function isTerminalOutputTool(toolName: string): boolean {
   return toolName.toLowerCase() === "bash";
-}
-
-/**
- * Keep tool cards compact without changing the full rawOutput payload. Preserve
- * both ends because failures and summaries commonly land at the end of output.
- */
-export function boundedToolOutput(content: string): string {
-  const trailingNewline = content.endsWith("\n");
-  const lines = content.split("\n");
-  if (trailingNewline) lines.pop();
-  let display = content;
-  if (lines.length > TOOL_OUTPUT_DISPLAY_LINES) {
-    const side = TOOL_OUTPUT_DISPLAY_LINES / 2;
-    const omitted = lines.length - TOOL_OUTPUT_DISPLAY_LINES;
-    display = `${[
-      ...lines.slice(0, side),
-      `… ${omitted} lines omitted from display …`,
-      ...lines.slice(-side),
-    ].join("\n")}${trailingNewline ? "\n" : ""}`;
-  }
-
-  const encoded = Buffer.from(display);
-  if (encoded.byteLength <= TOOL_OUTPUT_DISPLAY_BYTES) return display;
-
-  const marker = "\n\n… output truncated for display …\n\n";
-  const markerBytes = Buffer.byteLength(marker);
-  const remaining = TOOL_OUTPUT_DISPLAY_BYTES - markerBytes;
-  const headBytes = Math.floor(remaining / 2);
-  const tailBytes = remaining - headBytes;
-  return `${decodeUtf8Boundary(encoded.subarray(0, headBytes), "head")}${marker}${decodeUtf8Boundary(
-    encoded.subarray(encoded.byteLength - tailBytes),
-    "tail",
-  )}`;
-}
-
-function decodeUtf8Boundary(bytes: Buffer, side: "head" | "tail"): string {
-  for (let offset = 0; offset < Math.min(4, bytes.byteLength); offset += 1) {
-    const candidate =
-      side === "head" ? bytes.subarray(0, bytes.byteLength - offset) : bytes.subarray(offset);
-    try {
-      return new TextDecoder("utf-8", { fatal: true }).decode(candidate);
-    } catch {
-      // The byte slice may start or end inside a multibyte codepoint.
-    }
-  }
-  return "";
 }
 
 /** Parse tool output for ACP rawOutput while preserving non-JSON text. */
@@ -196,10 +147,11 @@ export function toolTitle(
   toolInput: Record<string, unknown>,
 ): string {
   if (isTerminalOutputTool(toolName)) {
-    const command = firstString(toolInput, ["command"]);
-    // Keep the executable command intact: shortening or replacing it with a
-    // friendly description can hide the operation a user is approving.
-    return command ?? toolName;
+    return (
+      firstString(toolInput, ["description"]) ??
+      firstString(toolInput, ["command"]) ??
+      toolName
+    );
   }
   const detail =
     firstString(toolInput, [

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -296,14 +296,6 @@ class FakeAppServer {
     }
 
     const promptText = JSON.stringify(payload.messages);
-    if (promptText.includes("long fragmented prompt")) {
-      this.streamFragmentedToolCall(
-        socket,
-        runtime,
-        `${Array.from({ length: 200 }, (_, index) => index + 1).join("\n")}\n`,
-      );
-      return;
-    }
     if (promptText.includes("fragmented prompt")) {
       this.streamFragmentedToolCall(socket, runtime);
       return;
@@ -453,7 +445,6 @@ class FakeAppServer {
   private streamFragmentedToolCall(
     socket: ServerSocket,
     runtime: RuntimeScope,
-    output = "nothing to commit",
   ): void {
     const fragments = [
       { name: "Bash", arguments: '{"command":"git status"' },
@@ -471,7 +462,7 @@ class FakeAppServer {
       message_type: "tool_return_message",
       run_id: "run-fragmented",
       tool_call_id: "call-fragmented",
-      tool_return: output,
+      tool_return: "nothing to commit",
       status: "success",
     });
     this.pushDelta(socket, runtime, {
@@ -764,7 +755,7 @@ describe("Agent SDK app-server integration", () => {
         {
           sessionUpdate: "tool_call_update",
           toolCallId: "call-fragmented",
-          title: "git status",
+          title: "Show the working tree status",
           kind: "execute",
           status: "in_progress",
           rawInput: {
@@ -836,7 +827,7 @@ describe("Agent SDK app-server integration", () => {
         {
           sessionUpdate: "tool_call_update",
           toolCallId: "call-fragmented",
-          title: "git status",
+          title: "Show the working tree status",
           kind: "execute",
           status: "in_progress",
           rawInput: {
@@ -869,49 +860,6 @@ describe("Agent SDK app-server integration", () => {
           },
         },
       ]);
-    } finally {
-      agent.shutdown();
-    }
-  });
-
-  test("caps native terminal display without truncating rawOutput", async () => {
-    const server = new FakeAppServer();
-    const agent = createAgent(server);
-    const { context, updates } = createContext();
-
-    try {
-      await agent.initialize({
-        protocolVersion: 1,
-        clientCapabilities: { _meta: { terminal_output: true } },
-      });
-      const session = await agent.newSession(
-        { cwd: "/tmp/letta-acp-test", mcpServers: [] },
-        context,
-      );
-      await agent.prompt(
-        {
-          sessionId: session.sessionId,
-          prompt: [{ type: "text", text: "long fragmented prompt" }],
-        },
-        context,
-      );
-
-      const terminalOutput = updates.find(
-        (update) =>
-          update.toolCallId === "call-fragmented" &&
-          (update._meta as WireMessage | undefined)?.terminal_output,
-      );
-      const displayed = (
-        (terminalOutput?._meta as WireMessage).terminal_output as WireMessage
-      ).data as string;
-      expect(displayed.trimEnd().split("\n")).toHaveLength(25);
-      expect(displayed).toContain("… 176 lines omitted from display …");
-
-      const completed = updates.find(
-        (update) =>
-          update.toolCallId === "call-fragmented" && update.status === "completed",
-      );
-      expect((completed?.rawOutput as string).trimEnd().split("\n")).toHaveLength(200);
     } finally {
       agent.shutdown();
     }
@@ -999,7 +947,7 @@ describe("Agent SDK app-server integration", () => {
         expect.objectContaining({
           sessionId: session.sessionId,
           toolCall: expect.objectContaining({
-            title: "pwd",
+            title: "Show working directory after prompt",
           }),
         }),
       );

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -296,6 +296,14 @@ class FakeAppServer {
     }
 
     const promptText = JSON.stringify(payload.messages);
+    if (promptText.includes("long fragmented prompt")) {
+      this.streamFragmentedToolCall(
+        socket,
+        runtime,
+        `${Array.from({ length: 200 }, (_, index) => index + 1).join("\n")}\n`,
+      );
+      return;
+    }
     if (promptText.includes("fragmented prompt")) {
       this.streamFragmentedToolCall(socket, runtime);
       return;
@@ -445,6 +453,7 @@ class FakeAppServer {
   private streamFragmentedToolCall(
     socket: ServerSocket,
     runtime: RuntimeScope,
+    output = "nothing to commit",
   ): void {
     const fragments = [
       { name: "Bash", arguments: '{"command":"git status"' },
@@ -462,7 +471,7 @@ class FakeAppServer {
       message_type: "tool_return_message",
       run_id: "run-fragmented",
       tool_call_id: "call-fragmented",
-      tool_return: "nothing to commit",
+      tool_return: output,
       status: "success",
     });
     this.pushDelta(socket, runtime, {
@@ -860,6 +869,49 @@ describe("Agent SDK app-server integration", () => {
           },
         },
       ]);
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("caps native terminal display without truncating rawOutput", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context, updates } = createContext();
+
+    try {
+      await agent.initialize({
+        protocolVersion: 1,
+        clientCapabilities: { _meta: { terminal_output: true } },
+      });
+      const session = await agent.newSession(
+        { cwd: "/tmp/letta-acp-test", mcpServers: [] },
+        context,
+      );
+      await agent.prompt(
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "long fragmented prompt" }],
+        },
+        context,
+      );
+
+      const terminalOutput = updates.find(
+        (update) =>
+          update.toolCallId === "call-fragmented" &&
+          (update._meta as WireMessage | undefined)?.terminal_output,
+      );
+      const displayed = (
+        (terminalOutput?._meta as WireMessage).terminal_output as WireMessage
+      ).data as string;
+      expect(displayed.trimEnd().split("\n")).toHaveLength(25);
+      expect(displayed).toContain("… 176 lines omitted from display …");
+
+      const completed = updates.find(
+        (update) =>
+          update.toolCallId === "call-fragmented" && update.status === "completed",
+      );
+      expect((completed?.rawOutput as string).trimEnd().split("\n")).toHaveLength(200);
     } finally {
       agent.shutdown();
     }

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -755,7 +755,7 @@ describe("Agent SDK app-server integration", () => {
         {
           sessionUpdate: "tool_call_update",
           toolCallId: "call-fragmented",
-          title: "Bash: Show the working tree status",
+          title: "git status",
           kind: "execute",
           status: "in_progress",
           rawInput: {
@@ -775,6 +775,89 @@ describe("Agent SDK app-server integration", () => {
               content: { type: "text", text: "nothing to commit" },
             },
           ],
+        },
+      ]);
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("renders Bash output as a native terminal when the client supports it", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context, updates } = createContext();
+
+    try {
+      await agent.initialize({
+        protocolVersion: 1,
+        clientCapabilities: { _meta: { terminal_output: true } },
+      });
+      const session = await agent.newSession(
+        { cwd: "/tmp/letta-acp-test", mcpServers: [] },
+        context,
+      );
+      const result = await agent.prompt(
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "fragmented prompt" }],
+        },
+        context,
+      );
+
+      expect(result).toEqual({ stopReason: "end_turn" });
+      expect(
+        updates.filter((update) => update.toolCallId === "call-fragmented"),
+      ).toEqual([
+        {
+          sessionUpdate: "tool_call",
+          toolCallId: "call-fragmented",
+          title: "Bash",
+          kind: "execute",
+          status: "in_progress",
+          rawInput: { raw: '{"command":"git status"' },
+          locations: [],
+          content: [{ type: "terminal", terminalId: "call-fragmented" }],
+          _meta: {
+            terminal_info: {
+              terminal_id: "call-fragmented",
+              cwd: "/tmp/letta-acp-test",
+            },
+          },
+        },
+        {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call-fragmented",
+          title: "git status",
+          kind: "execute",
+          status: "in_progress",
+          rawInput: {
+            command: "git status",
+            description: "Show the working tree status",
+          },
+          locations: [],
+        },
+        {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call-fragmented",
+          _meta: {
+            terminal_output: {
+              terminal_id: "call-fragmented",
+              data: "nothing to commit",
+            },
+          },
+        },
+        {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call-fragmented",
+          status: "completed",
+          rawOutput: "nothing to commit",
+          _meta: {
+            terminal_exit: {
+              terminal_id: "call-fragmented",
+              exit_code: 0,
+              signal: null,
+            },
+          },
         },
       ]);
     } finally {
@@ -864,7 +947,7 @@ describe("Agent SDK app-server integration", () => {
         expect.objectContaining({
           sessionId: session.sessionId,
           toolCall: expect.objectContaining({
-            title: "Bash: Show working directory after prompt",
+            title: "pwd",
           }),
         }),
       );

--- a/test/history-replay.test.ts
+++ b/test/history-replay.test.ts
@@ -58,6 +58,59 @@ describe("tool history replay", () => {
     expect(updates[1]).not.toHaveProperty("content");
   });
 
+  test("replays Bash output through native terminal metadata when supported", () => {
+    const updates = historyToUpdates(
+      [
+        {
+          message_type: "tool_call_message",
+          tool_calls: [
+            {
+              tool_call_id: "call-bash",
+              name: "Bash",
+              arguments: JSON.stringify({ command: "pwd" }),
+            },
+          ],
+        },
+        {
+          message_type: "tool_return_message",
+          tool_call_id: "call-bash",
+          status: "success",
+          tool_return: "/tmp/project",
+        },
+      ],
+      { terminalOutput: true, cwd: "/tmp/project" },
+    );
+
+    expect(updates).toEqual([
+      expect.objectContaining({
+        sessionUpdate: "tool_call",
+        status: "in_progress",
+        content: [{ type: "terminal", terminalId: "call-bash" }],
+        _meta: {
+          terminal_info: { terminal_id: "call-bash", cwd: "/tmp/project" },
+        },
+      }),
+      {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "call-bash",
+        _meta: {
+          terminal_output: { terminal_id: "call-bash", data: "/tmp/project" },
+        },
+      },
+      expect.objectContaining({
+        sessionUpdate: "tool_call_update",
+        status: "completed",
+        _meta: {
+          terminal_exit: {
+            terminal_id: "call-bash",
+            exit_code: 0,
+            signal: null,
+          },
+        },
+      }),
+    ]);
+  });
+
   test("preserves text output for non-edit tools", () => {
     const updates = historyToUpdates([
       {

--- a/test/tool-info.test.ts
+++ b/test/tool-info.test.ts
@@ -93,7 +93,22 @@ describe("tool output fallback", () => {
     expect(boundedToolOutput("hello")).toBe("hello");
   });
 
-  test("bounds long output while preserving its head, tail, and UTF-8", () => {
+  test("keeps only the first and last 12 lines", () => {
+    const output = `${Array.from({ length: 200 }, (_, index) => index + 1).join("\n")}\n`;
+    const bounded = boundedToolOutput(output);
+    const lines = bounded.trimEnd().split("\n");
+
+    expect(lines).toHaveLength(25);
+    expect(lines.slice(0, 12)).toEqual(
+      Array.from({ length: 12 }, (_, index) => String(index + 1)),
+    );
+    expect(lines[12]).toBe("… 176 lines omitted from display …");
+    expect(lines.slice(-12)).toEqual(
+      Array.from({ length: 12 }, (_, index) => String(index + 189)),
+    );
+  });
+
+  test("bounds a long line while preserving its head, tail, and UTF-8", () => {
     const output = `${"a".repeat(12_000)}🙂${"z".repeat(12_000)}`;
     const bounded = boundedToolOutput(output);
 

--- a/test/tool-info.test.ts
+++ b/test/tool-info.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   accumulateToolInput,
+  boundedToolOutput,
   parseToolOutput,
   toolDiffContent,
   toolLocations,
@@ -26,9 +27,7 @@ describe("fragmented tool arguments", () => {
       command: "git status",
       description: "Show working tree status",
     });
-    expect(toolTitle("Bash", complete.input)).toBe(
-      "Bash: Show working tree status",
-    );
+    expect(toolTitle("Bash", complete.input)).toBe("git status");
     expect(complete.complete).toBe(true);
   });
 
@@ -86,6 +85,23 @@ describe("fragmented tool arguments", () => {
     );
     expect(complete.input).toEqual(input);
     expect(toolLocations(complete.input)).toEqual([{ path: "/tmp/example.ts" }]);
+  });
+});
+
+describe("tool output fallback", () => {
+  test("preserves short output", () => {
+    expect(boundedToolOutput("hello")).toBe("hello");
+  });
+
+  test("bounds long output while preserving its head, tail, and UTF-8", () => {
+    const output = `${"a".repeat(12_000)}🙂${"z".repeat(12_000)}`;
+    const bounded = boundedToolOutput(output);
+
+    expect(Buffer.byteLength(bounded)).toBeLessThanOrEqual(16 * 1024);
+    expect(bounded.startsWith("aaaa")).toBe(true);
+    expect(bounded.endsWith("zzzz")).toBe(true);
+    expect(bounded).toContain("output truncated for display");
+    expect(bounded).not.toContain("�");
   });
 });
 

--- a/test/tool-info.test.ts
+++ b/test/tool-info.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   accumulateToolInput,
-  boundedToolOutput,
   parseToolOutput,
   toolDiffContent,
   toolLocations,
@@ -27,7 +26,7 @@ describe("fragmented tool arguments", () => {
       command: "git status",
       description: "Show working tree status",
     });
-    expect(toolTitle("Bash", complete.input)).toBe("git status");
+    expect(toolTitle("Bash", complete.input)).toBe("Show working tree status");
     expect(complete.complete).toBe(true);
   });
 
@@ -85,38 +84,6 @@ describe("fragmented tool arguments", () => {
     );
     expect(complete.input).toEqual(input);
     expect(toolLocations(complete.input)).toEqual([{ path: "/tmp/example.ts" }]);
-  });
-});
-
-describe("tool output fallback", () => {
-  test("preserves short output", () => {
-    expect(boundedToolOutput("hello")).toBe("hello");
-  });
-
-  test("keeps only the first and last 12 lines", () => {
-    const output = `${Array.from({ length: 200 }, (_, index) => index + 1).join("\n")}\n`;
-    const bounded = boundedToolOutput(output);
-    const lines = bounded.trimEnd().split("\n");
-
-    expect(lines).toHaveLength(25);
-    expect(lines.slice(0, 12)).toEqual(
-      Array.from({ length: 12 }, (_, index) => String(index + 1)),
-    );
-    expect(lines[12]).toBe("… 176 lines omitted from display …");
-    expect(lines.slice(-12)).toEqual(
-      Array.from({ length: 12 }, (_, index) => String(index + 189)),
-    );
-  });
-
-  test("bounds a long line while preserving its head, tail, and UTF-8", () => {
-    const output = `${"a".repeat(12_000)}🙂${"z".repeat(12_000)}`;
-    const bounded = boundedToolOutput(output);
-
-    expect(Buffer.byteLength(bounded)).toBeLessThanOrEqual(16 * 1024);
-    expect(bounded.startsWith("aaaa")).toBe(true);
-    expect(bounded.endsWith("zzzz")).toBe(true);
-    expect(bounded).toContain("output truncated for display");
-    expect(bounded).not.toContain("�");
   });
 });
 


### PR DESCRIPTION
## Summary

- detect Zed-compatible `_meta.terminal_output` support during ACP initialization
- render Bash calls with native terminal content and ordered `terminal_info`, `terminal_output`, and `terminal_exit` updates
- use the Bash `description` as the readable card title, falling back to the command when no description exists
- send complete command output and let the ACP client own expansion and collapse behavior

## Before / after

Previously every Bash result was attached to the generic ACP tool card as a potentially large text block. Terminal-capable clients now receive the display-only terminal lifecycle used by Claude ACP and consumed by Zed.

The adapter does not impose a separate output limit. Zed owns presentation through its `agent.expand_terminal_card` setting; setting it to `false` keeps terminal cards collapsed until opened. File-edit diffs and non-Bash tool output are unchanged.

The command still executes in the Letta runtime; this PR changes rendering only and does not delegate execution through ACP `terminal/*` requests. The complete result remains available in `rawOutput`.

## Validation

- [x] `bun run check` — 40 tests, typecheck, and build
- [x] Agent SDK integration test covers the exact Zed terminal metadata lifecycle
- [x] session history replay covers native terminal reconstruction
- [x] generic-client `acpx` lifecycle tests remain green
- [x] manually verified native terminal rendering in Zed
- [x] verified Zed’s source-controlled `agent.expand_terminal_card` setting and configured the local test client with `false`

## Compatibility

Clients that do not advertise `_meta.terminal_output` retain the existing generic text result path.

👾 Generated with [Letta Code](https://letta.com)