### PR TITLE
fix: allow task bookkeeping without prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,10 +203,11 @@ adapter restarts with no local state: the conversation is resumed via the SDK
 and its recent history (up to 200 messages) is replayed as `session/update`
 notifications. Session modes are enforced in the adapter's permission
 callback — the harness always runs in `standard` mode so every approval routes
-through the adapter, which is what makes live mode switching possible;
-`acceptEdits` auto-allows file-edit tools, `unrestricted` auto-allows
-everything. `/model` (empty to list, or a handle to switch) is handled in the
-adapter without an LLM turn.
+through the adapter, which is what makes live mode switching possible. Session
+bookkeeping tools (`TaskCreate`, `TaskGet`, `TaskList`, `TaskUpdate`, and
+`TodoWrite`) never require approval; `acceptEdits` additionally auto-allows
+file-edit tools, and `unrestricted` auto-allows everything. `/model` (empty to
+list, or a handle to switch) is handled in the adapter without an LLM turn.
 
 ### Slash commands
 

--- a/src/session-modes.ts
+++ b/src/session-modes.ts
@@ -15,6 +15,19 @@ export const SESSION_MODE_IDS: PermissionMode[] = [
   "unrestricted",
 ];
 
+/**
+ * Session bookkeeping does not read files, edit the workspace, or execute
+ * commands. Match the Letta harness, which marks these tools as not requiring
+ * approval, so progress tracking never interrupts an otherwise safe turn.
+ */
+const BOOKKEEPING_TOOLS = new Set([
+  "TaskCreate",
+  "TaskGet",
+  "TaskList",
+  "TaskUpdate",
+  "TodoWrite",
+]);
+
 /** Tools auto-allowed in acceptEdits mode. */
 const EDIT_TOOLS = new Set([
   "Edit",
@@ -54,6 +67,7 @@ export function sessionModeState(currentModeId: PermissionMode): SessionModeStat
 /** Whether the adapter should auto-allow this tool under the given mode. */
 export function modeAutoAllows(mode: PermissionMode, toolName: string): boolean {
   if (mode === "unrestricted") return true;
+  if (BOOKKEEPING_TOOLS.has(toolName)) return true;
   if (mode === "acceptEdits") return EDIT_TOOLS.has(toolName);
   return false;
 }

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -958,6 +958,40 @@ describe("Agent SDK app-server integration", () => {
     }
   });
 
+  test("auto-allows task bookkeeping in ask-before-edits mode", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context, permissionRequests } = createContext();
+
+    try {
+      const session = await openSession(agent, context);
+      await agent.prompt(
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "plain prompt" }],
+        },
+        context,
+      );
+      const approval = server.nextApprovalResponse();
+      server.requestPermissionAfterPrompt({
+        requestId: "task-update-request",
+        toolName: "TaskUpdate",
+        toolCallId: "call-task-update",
+        input: { taskId: "task_1", status: "completed" },
+      });
+
+      expect(await approval).toEqual(
+        expect.objectContaining({
+          request_id: "task-update-request",
+          decision: expect.objectContaining({ behavior: "allow" }),
+        }),
+      );
+      expect(permissionRequests).toEqual([]);
+    } finally {
+      agent.shutdown();
+    }
+  });
+
   test("attaches a permission request to the tool call it belongs to", async () => {
     const server = new FakeAppServer();
     const agent = createAgent(server);

--- a/test/session-modes.test.ts
+++ b/test/session-modes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { modeAutoAllows } from "../src/session-modes.js";
+
+const BOOKKEEPING_TOOLS = [
+  "TaskCreate",
+  "TaskGet",
+  "TaskList",
+  "TaskUpdate",
+  "TodoWrite",
+];
+
+describe("session mode tool approvals", () => {
+  test.each(BOOKKEEPING_TOOLS)(
+    "auto-allows %s in ask-before-edits mode",
+    (toolName) => {
+      expect(modeAutoAllows("standard", toolName)).toBe(true);
+    },
+  );
+
+  test("still asks before workspace mutations and commands", () => {
+    expect(modeAutoAllows("standard", "Edit")).toBe(false);
+    expect(modeAutoAllows("standard", "Write")).toBe(false);
+    expect(modeAutoAllows("standard", "Bash")).toBe(false);
+  });
+
+  test("keeps accept-edits and unrestricted behavior", () => {
+    expect(modeAutoAllows("acceptEdits", "Edit")).toBe(true);
+    expect(modeAutoAllows("acceptEdits", "Bash")).toBe(false);
+    expect(modeAutoAllows("unrestricted", "Bash")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- auto-allow `TaskCreate`, `TaskGet`, `TaskList`, `TaskUpdate`, and `TodoWrite` in every ACP session mode
- keep file edits and shell commands gated in the default **Ask before edits** mode
- align these bookkeeping tools with the Letta harness, where they do not require approval

## Before / after

Previously a routine `TaskUpdate` interrupted a standard-mode Zed turn with an approval prompt even though it only updated session task state.

Now task bookkeeping proceeds automatically. Workspace mutations and command execution retain their existing permission behavior.

## Validation

- [x] `bun run check` — 48 tests, typecheck, and build
- [x] integration regression crosses the app-server approval callback and confirms `TaskUpdate` is allowed without an ACP permission request
- [x] focused mode tests cover all five bookkeeping tools plus negative controls for `Edit`, `Write`, and `Bash`

## Scope

This PR only changes session task bookkeeping. Broader read-only-tool permission alignment is intentionally separate.

👾 Generated with [Letta Code](https://letta.com)