### PR TITLE
fix: restore permission selection with model options

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -47,6 +47,8 @@ import { SessionRegistry } from "./session-registry.js";
 import {
   isSessionModeId,
   modeAutoAllows,
+  PERMISSION_MODE_CONFIG_ID,
+  permissionModeConfigOption,
   sessionModeState,
 } from "./session-modes.js";
 import {
@@ -219,7 +221,7 @@ export class LettaAcpAgent {
     return {
       sessionId,
       modes: sessionModeState(state.modeId),
-      configOptions: await this.modelConfigOptions(state),
+      configOptions: await this.sessionConfigOptions(state),
     };
   }
 
@@ -263,7 +265,7 @@ export class LettaAcpAgent {
     this.announceCommands(sessionId, cx);
     return {
       modes: sessionModeState(state.modeId),
-      configOptions: await this.modelConfigOptions(state),
+      configOptions: await this.sessionConfigOptions(state),
     };
   }
 
@@ -344,7 +346,7 @@ export class LettaAcpAgent {
     }
   }
 
-  private async modelConfigOptions(
+  private async sessionConfigOptions(
     state: AcpSessionState,
   ): Promise<SessionConfigOption[]> {
     const { entries } = await state.session.listModels();
@@ -370,10 +372,11 @@ export class LettaAcpAgent {
       currentValue = state.currentModel;
       options.unshift({ value: state.currentModel, name: state.currentModel });
     }
-    if (!currentValue) return [];
-
-    return [
-      {
+    const configOptions: SessionConfigOption[] = [
+      permissionModeConfigOption(state.modeId),
+    ];
+    if (currentValue) {
+      configOptions.push({
         id: "model",
         name: "Model",
         description: "Model used for this Letta session",
@@ -381,8 +384,9 @@ export class LettaAcpAgent {
         type: "select",
         currentValue,
         options,
-      },
-    ];
+      });
+    }
+    return configOptions;
   }
 
   async setSessionConfigOption(
@@ -392,17 +396,24 @@ export class LettaAcpAgent {
     if (!state) {
       throw new Error(`Unknown session: ${params.sessionId}`);
     }
-    if (params.configId !== "model") {
-      throw new Error(`Unknown session configuration option: ${params.configId}`);
+    if (params.configId === PERMISSION_MODE_CONFIG_ID) {
+      if (typeof params.value !== "string" || !isSessionModeId(params.value)) {
+        throw new Error(`Unknown permission mode: ${String(params.value)}`);
+      }
+      state.modeId = params.value;
+      log(`session ${params.sessionId} mode -> ${params.value}`);
+      return { configOptions: await this.sessionConfigOptions(state) };
     }
-    if (typeof params.value !== "string") {
-      throw new Error("The model configuration option requires a model id");
+    if (params.configId === "model") {
+      if (typeof params.value !== "string") {
+        throw new Error("The model configuration option requires a model id");
+      }
+      const result = await state.session.updateModel(params.value);
+      state.currentModel = result.modelHandle ?? result.modelId ?? params.value;
+      log(`session ${params.sessionId} model -> ${state.currentModel}`);
+      return { configOptions: await this.sessionConfigOptions(state) };
     }
-
-    const result = await state.session.updateModel(params.value);
-    state.currentModel = result.modelHandle ?? result.modelId ?? params.value;
-    log(`session ${params.sessionId} model -> ${state.currentModel}`);
-    return { configOptions: await this.modelConfigOptions(state) };
+    throw new Error(`Unknown session configuration option: ${params.configId}`);
   }
 
   async setSessionMode(

--- a/src/session-modes.ts
+++ b/src/session-modes.ts
@@ -1,4 +1,7 @@
-import type { SessionModeState } from "@agentclientprotocol/sdk";
+import type {
+  SessionConfigOption,
+  SessionModeState,
+} from "@agentclientprotocol/sdk";
 import type { PermissionMode } from "@letta-ai/letta-agent-sdk";
 
 /**
@@ -14,6 +17,26 @@ export const SESSION_MODE_IDS: PermissionMode[] = [
   "acceptEdits",
   "unrestricted",
 ];
+
+export const PERMISSION_MODE_CONFIG_ID = "permissions";
+
+const SESSION_MODES = [
+  {
+    id: "standard",
+    name: "Ask before edits",
+    description: "Request permission for file edits and shell commands",
+  },
+  {
+    id: "acceptEdits",
+    name: "Accept edits",
+    description: "Auto-allow file edits; still ask for shell commands",
+  },
+  {
+    id: "unrestricted",
+    name: "Bypass permissions",
+    description: "Auto-allow all tool calls without asking",
+  },
+] as const;
 
 /**
  * Session bookkeeping does not read files, edit the workspace, or execute
@@ -44,23 +67,30 @@ export function isSessionModeId(value: string): value is PermissionMode {
 export function sessionModeState(currentModeId: PermissionMode): SessionModeState {
   return {
     currentModeId,
-    availableModes: [
-      {
-        id: "standard",
-        name: "Ask before edits",
-        description: "Request permission for file edits and shell commands",
-      },
-      {
-        id: "acceptEdits",
-        name: "Accept edits",
-        description: "Auto-allow file edits; still ask for shell commands",
-      },
-      {
-        id: "unrestricted",
-        name: "Bypass permissions",
-        description: "Auto-allow all tool calls without asking",
-      },
-    ],
+    availableModes: SESSION_MODES.map((mode) => ({ ...mode })),
+  };
+}
+
+/**
+ * Modern ACP clients render session modes from category=mode config options.
+ * Keep the legacy `modes` response too for clients that still use
+ * `session/set_mode`.
+ */
+export function permissionModeConfigOption(
+  currentModeId: PermissionMode,
+): SessionConfigOption {
+  return {
+    id: PERMISSION_MODE_CONFIG_ID,
+    name: "Permissions",
+    description: "Approval behavior for tool calls",
+    category: "mode",
+    type: "select",
+    currentValue: currentModeId,
+    options: SESSION_MODES.map((mode) => ({
+      value: mode.id,
+      name: mode.name,
+      description: mode.description,
+    })),
   };
 }
 

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -774,6 +774,22 @@ describe("Agent SDK app-server integration", () => {
 
       expect(session.configOptions).toEqual([
         {
+          id: "permissions",
+          name: "Permissions",
+          description: "Approval behavior for tool calls",
+          category: "mode",
+          type: "select",
+          currentValue: "standard",
+          options: [
+            expect.objectContaining({ value: "standard", name: "Ask before edits" }),
+            expect.objectContaining({ value: "acceptEdits", name: "Accept edits" }),
+            expect.objectContaining({
+              value: "unrestricted",
+              name: "Bypass permissions",
+            }),
+          ],
+        },
+        {
           id: "model",
           name: "Model",
           description: "Model used for this Letta session",
@@ -813,11 +829,51 @@ describe("Agent SDK app-server integration", () => {
       });
 
       expect(server.updatedModelPayloads).toEqual([{ model_id: "other-model" }]);
-      expect(result.configOptions[0]).toMatchObject({
+      expect(
+        result.configOptions.find((option) => option.id === "model"),
+      ).toMatchObject({
         id: "model",
         category: "model",
         currentValue: "other-model",
       });
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("switches permission enforcement through session config options", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context, permissionRequests } = createContext();
+
+    try {
+      const session = await openSession(agent, context);
+      const result = await agent.setSessionConfigOption({
+        sessionId: session.sessionId,
+        configId: "permissions",
+        value: "unrestricted",
+      });
+      expect(
+        result.configOptions.find((option) => option.id === "permissions"),
+      ).toMatchObject({
+        category: "mode",
+        currentValue: "unrestricted",
+      });
+
+      await agent.prompt(
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "plain prompt" }],
+        },
+        context,
+      );
+      const approval = server.nextApprovalResponse();
+      server.requestPermissionAfterPrompt();
+
+      expect(await approval).toMatchObject({
+        decision: { behavior: "allow" },
+      });
+      expect(permissionRequests).toEqual([]);
     } finally {
       agent.shutdown();
     }

--- a/test/session-modes.test.ts
+++ b/test/session-modes.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { modeAutoAllows } from "../src/session-modes.js";
+import {
+  modeAutoAllows,
+  permissionModeConfigOption,
+} from "../src/session-modes.js";
 
 const BOOKKEEPING_TOOLS = [
   "TaskCreate",
@@ -10,6 +13,34 @@ const BOOKKEEPING_TOOLS = [
 ];
 
 describe("session mode tool approvals", () => {
+  test("publishes permissions as a modern ACP mode config option", () => {
+    expect(permissionModeConfigOption("unrestricted")).toEqual({
+      id: "permissions",
+      name: "Permissions",
+      description: "Approval behavior for tool calls",
+      category: "mode",
+      type: "select",
+      currentValue: "unrestricted",
+      options: [
+        {
+          value: "standard",
+          name: "Ask before edits",
+          description: "Request permission for file edits and shell commands",
+        },
+        {
+          value: "acceptEdits",
+          name: "Accept edits",
+          description: "Auto-allow file edits; still ask for shell commands",
+        },
+        {
+          value: "unrestricted",
+          name: "Bypass permissions",
+          description: "Auto-allow all tool calls without asking",
+        },
+      ],
+    });
+  });
+
   test.each(BOOKKEEPING_TOOLS)(
     "auto-allows %s in ask-before-edits mode",
     (toolName) => {


### PR DESCRIPTION
## Summary
- publish adapter permission modes as an ACP `configOptions` selector with `category: "mode"`
- keep the legacy `modes` / `session/set_mode` path for older ACP clients
- apply permission changes from `session/set_config_option` to the adapter enforcement state

## Why
Zed 1.13 treats legacy `modes` and modern `configOptions` as mutually exclusive. Once letta-acp added a model config option, Zed retained the model selector and discarded the permission modes, removing the permission control from the composer.

## Validation
- [x] `bun run check` — 61 tests, typecheck, and build
- [x] `bun run test:acpx` — real ACP stdio client boundary
- [x] integration test proves selecting unrestricted through `session/set_config_option` auto-allows a Bash approval without prompting
- [x] legacy mode response remains covered

👾 Generated with [Letta Code](https://letta.com)