### PR TITLE
fix: preserve portable output with presentation extensions

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -64,6 +64,7 @@ import {
   toolKind,
   toolLocations,
   toolOutputLine,
+  toolResultContent,
   toolTitle,
 } from "./tool-info.js";
 
@@ -968,6 +969,15 @@ export class LettaAcpAgent {
             },
           });
         }
+        const resultContent = toolResultContent(
+          message.toolCallId,
+          message.content,
+          {
+            includeTerminal: nativeTerminal,
+            hasDiff: toolCall?.hasDiff,
+            isError: message.isError,
+          },
+        );
         await cx.notify(methods.client.session.update, {
           sessionId,
           update: {
@@ -976,25 +986,9 @@ export class LettaAcpAgent {
             status: message.isError ? "failed" : "completed",
             rawOutput,
             ...(locations.length > 0 ? { locations } : {}),
+            ...(resultContent.length > 0 ? { content: resultContent } : {}),
             ...(nativeTerminal
               ? {
-                  // Keep standard ACP text beside Zed's terminal extension. Zed
-                  // uses the terminal when it resolves; if it does not, the text
-                  // keeps the generic execute card expandable instead of leaving
-                  // a copy-only command preview with no visible result.
-                  content: [
-                    {
-                      type: "terminal" as const,
-                      terminalId: message.toolCallId,
-                    },
-                    {
-                      type: "content" as const,
-                      content: {
-                        type: "text" as const,
-                        text: message.content,
-                      },
-                    },
-                  ],
                   _meta: {
                     terminal_exit: {
                       terminal_id: message.toolCallId,
@@ -1003,19 +997,7 @@ export class LettaAcpAgent {
                     },
                   },
                 }
-              : toolCall?.hasDiff !== true || message.isError
-                ? {
-                    content: [
-                      {
-                        type: "content" as const,
-                        content: {
-                          type: "text" as const,
-                          text: message.content,
-                        },
-                      },
-                    ],
-                  }
-                : {}),
+              : {}),
           },
         });
         return true;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -978,6 +978,23 @@ export class LettaAcpAgent {
             ...(locations.length > 0 ? { locations } : {}),
             ...(nativeTerminal
               ? {
+                  // Keep standard ACP text beside Zed's terminal extension. Zed
+                  // uses the terminal when it resolves; if it does not, the text
+                  // keeps the generic execute card expandable instead of leaving
+                  // a copy-only command preview with no visible result.
+                  content: [
+                    {
+                      type: "terminal" as const,
+                      terminalId: message.toolCallId,
+                    },
+                    {
+                      type: "content" as const,
+                      content: {
+                        type: "text" as const,
+                        text: message.content,
+                      },
+                    },
+                  ],
                   _meta: {
                     terminal_exit: {
                       terminal_id: message.toolCallId,

--- a/src/history-replay.ts
+++ b/src/history-replay.ts
@@ -141,6 +141,20 @@ export function historyToUpdates(
           ...(locations.length > 0 ? { locations } : {}),
           ...(nativeTerminal
             ? {
+                // Preserve a standard ACP fallback for clients that advertise
+                // Zed's terminal extension but cannot resolve a replayed
+                // display terminal into an expandable card.
+                ...(text
+                  ? {
+                      content: [
+                        { type: "terminal" as const, terminalId: toolCallId },
+                        {
+                          type: "content" as const,
+                          content: { type: "text" as const, text },
+                        },
+                      ],
+                    }
+                  : {}),
                 _meta: {
                   terminal_exit: {
                     terminal_id: toolCallId,

--- a/src/history-replay.ts
+++ b/src/history-replay.ts
@@ -6,6 +6,7 @@ import {
   toolKind,
   toolLocations,
   toolOutputLine,
+  toolResultContent,
   toolTitle,
 } from "./tool-info.js";
 
@@ -124,6 +125,14 @@ export function historyToUpdates(
         const locations = input
           ? toolLocations(input, toolOutputLine(rawOutput))
           : [];
+        const resultContent =
+          text !== undefined
+            ? toolResultContent(toolCallId, text, {
+                includeTerminal: nativeTerminal,
+                hasDiff,
+                isError: failed,
+              })
+            : [];
         if (nativeTerminal && text !== undefined) {
           updates.push({
             sessionUpdate: "tool_call_update",
@@ -139,22 +148,9 @@ export function historyToUpdates(
           status: failed ? "failed" : "completed",
           ...(rawOutput !== undefined ? { rawOutput } : {}),
           ...(locations.length > 0 ? { locations } : {}),
+          ...(resultContent.length > 0 ? { content: resultContent } : {}),
           ...(nativeTerminal
             ? {
-                // Preserve a standard ACP fallback for clients that advertise
-                // Zed's terminal extension but cannot resolve a replayed
-                // display terminal into an expandable card.
-                ...(text
-                  ? {
-                      content: [
-                        { type: "terminal" as const, terminalId: toolCallId },
-                        {
-                          type: "content" as const,
-                          content: { type: "text" as const, text },
-                        },
-                      ],
-                    }
-                  : {}),
                 _meta: {
                   terminal_exit: {
                     terminal_id: toolCallId,
@@ -163,16 +159,7 @@ export function historyToUpdates(
                   },
                 },
               }
-            : text && (!hasDiff || failed)
-              ? {
-                  content: [
-                    {
-                      type: "content",
-                      content: { type: "text", text },
-                    },
-                  ],
-                }
-              : {}),
+            : {}),
         });
         break;
       }

--- a/src/tool-info.ts
+++ b/src/tool-info.ts
@@ -132,6 +132,36 @@ export function isTerminalOutputTool(toolName: string): boolean {
   return toolName.toLowerCase() === "bash";
 }
 
+/**
+ * Portable result content for an ACP tool call.
+ *
+ * Presentation extensions are additive: a client-specific terminal reference
+ * may enhance the result, but ordinary ACP text remains available when the
+ * client ignores or cannot resolve that extension. Diff tools keep their
+ * structured diff as the success presentation and only add text on failure.
+ */
+export function toolResultContent(
+  toolCallId: string,
+  text: string,
+  options: {
+    includeTerminal?: boolean;
+    hasDiff?: boolean;
+    isError?: boolean;
+  } = {},
+): ToolCallContent[] {
+  const content: ToolCallContent[] = [];
+  if (options.includeTerminal) {
+    content.push({ type: "terminal", terminalId: toolCallId });
+  }
+  if (options.hasDiff !== true || options.isError === true) {
+    content.push({
+      type: "content",
+      content: { type: "text", text },
+    });
+  }
+  return content;
+}
+
 /** Parse tool output for ACP rawOutput while preserving non-JSON text. */
 export function parseToolOutput(content: string): unknown {
   try {

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -1031,6 +1031,13 @@ describe("Agent SDK app-server integration", () => {
           toolCallId: "call-fragmented",
           status: "completed",
           rawOutput: "nothing to commit",
+          content: [
+            { type: "terminal", terminalId: "call-fragmented" },
+            {
+              type: "content",
+              content: { type: "text", text: "nothing to commit" },
+            },
+          ],
           _meta: {
             terminal_exit: {
               terminal_id: "call-fragmented",

--- a/test/history-replay.test.ts
+++ b/test/history-replay.test.ts
@@ -100,6 +100,13 @@ describe("tool history replay", () => {
       expect.objectContaining({
         sessionUpdate: "tool_call_update",
         status: "completed",
+        content: [
+          { type: "terminal", terminalId: "call-bash" },
+          {
+            type: "content",
+            content: { type: "text", text: "/tmp/project" },
+          },
+        ],
         _meta: {
           terminal_exit: {
             terminal_id: "call-bash",

--- a/test/tool-info.test.ts
+++ b/test/tool-info.test.ts
@@ -5,6 +5,7 @@ import {
   toolDiffContent,
   toolLocations,
   toolOutputLine,
+  toolResultContent,
   toolTitle,
 } from "../src/tool-info.js";
 
@@ -26,6 +27,7 @@ describe("fragmented tool arguments", () => {
       command: "git status",
       description: "Show working tree status",
     });
+
     expect(toolTitle("Bash", complete.input)).toBe("Show working tree status");
     expect(complete.complete).toBe(true);
   });
@@ -173,6 +175,39 @@ describe("edit tool presentation", () => {
     ]);
     expect(toolLocations({ file_path: "C:\\repo\\example.ts" }, 12)).toEqual([
       { path: "C:\\repo\\example.ts", line: 12 },
+    ]);
+  });
+});
+
+describe("portable tool results", () => {
+  test("keeps text when a presentation extension is present", () => {
+    expect(
+      toolResultContent("call-bash", "command output", {
+        includeTerminal: true,
+      }),
+    ).toEqual([
+      { type: "terminal", terminalId: "call-bash" },
+      {
+        type: "content",
+        content: { type: "text", text: "command output" },
+      },
+    ]);
+  });
+
+  test("does not duplicate successful diff presentation", () => {
+    expect(
+      toolResultContent("call-edit", "edit applied", { hasDiff: true }),
+    ).toEqual([]);
+    expect(
+      toolResultContent("call-edit", "edit failed", {
+        hasDiff: true,
+        isError: true,
+      }),
+    ).toEqual([
+      {
+        type: "content",
+        content: { type: "text", text: "edit failed" },
+      },
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- guarantee portable ACP text output for completed non-diff tool calls
- treat native-terminal metadata as an additive presentation enhancement rather than the sole result representation
- apply the same invariant to live streaming and persisted-session replay
- keep successful edit tools on their structured diff presentation without duplicating result text

## Why
ACP clients should not need a vendor-specific presentation extension to inspect a tool result. The adapter previously sent Bash output exclusively through optional terminal metadata whenever the client advertised support. If that extension was ignored or could not resolve its display object, the remaining execute card had no portable content.

Tool results now always retain canonical ACP content. A terminal-capable client can render the terminal reference and metadata; a generic client can ignore unsupported presentation items and render the accompanying text. `rawOutput` remains available as structured machine-readable data but is not the only display source.

## Client impact
- **Generic ACP clients:** continue receiving ordinary text output; no extension support is required.
- **Terminal-capable clients:** retain native terminal metadata and also receive a text fallback. Clients may render the terminal, the fallback, or both according to their UI.
- **Diff-capable clients:** successful edit tools remain represented by their structured diff without duplicate success text; failures still include readable text.
- **Loaded sessions:** replay follows the same representation as live turns.

## Validation
- [x] `bun run check` — 63 tests, typecheck, and build
- [x] `bun run test:acpx` — real generic ACP stdio boundary
- [x] focused tests prove extensions remain additive and successful diff results are not duplicated
- [x] live and replay fixtures assert native-terminal metadata plus portable text

👾 Generated with [Letta Code](https://letta.com)