### PR TITLE
fix: align editor tools with permission modes

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -45,6 +45,7 @@ import { historyToUpdates } from "./history-replay.js";
 import { withAcpRequestTimeout } from "./request-timeout.js";
 import { SessionRegistry } from "./session-registry.js";
 import {
+  editorReadAutoAllows,
   isSessionModeId,
   modeAutoAllows,
   PERMISSION_MODE_CONFIG_ID,
@@ -1081,7 +1082,13 @@ export class LettaAcpAgent {
     toolInput: Record<string, unknown>,
     context: CanUseToolContext | undefined,
   ): Promise<CanUseToolResponse> {
-    if (modeAutoAllows(state.modeId, toolName)) {
+    const workspaceEditorRead = await editorReadAutoAllows(
+      state.modeId,
+      toolName,
+      toolInput,
+      state.cwd,
+    );
+    if (modeAutoAllows(state.modeId, toolName) || workspaceEditorRead) {
       log(`auto-allowing ${toolName} (mode ${state.modeId})`);
       return { behavior: "allow", updatedInput: toolInput };
     }

--- a/src/session-modes.ts
+++ b/src/session-modes.ts
@@ -3,7 +3,7 @@ import type {
   SessionModeState,
 } from "@agentclientprotocol/sdk";
 import type { PermissionMode } from "@letta-ai/letta-agent-sdk";
-import { realpath } from "node:fs/promises";
+import { lstat, realpath } from "node:fs/promises";
 import {
   basename,
   dirname,
@@ -167,6 +167,23 @@ async function canonicalBoundaryPath(path: string): Promise<string> {
       ) {
         throw error;
       }
+      // `realpath` also reports ENOENT for a dangling symlink. Do not treat
+      // that as a new in-workspace buffer: its eventual target is unconstrained.
+      let cursorIsMissing = false;
+      try {
+        await lstat(cursor);
+      } catch (statError) {
+        if (
+          statError &&
+          typeof statError === "object" &&
+          (statError as NodeJS.ErrnoException).code === "ENOENT"
+        ) {
+          cursorIsMissing = true;
+        } else {
+          throw statError;
+        }
+      }
+      if (!cursorIsMissing) throw error;
       const parent = dirname(cursor);
       if (parent === cursor) throw new Error(`Cannot resolve ${path}`);
       missingSegments.unshift(basename(cursor));

--- a/src/session-modes.ts
+++ b/src/session-modes.ts
@@ -3,6 +3,15 @@ import type {
   SessionModeState,
 } from "@agentclientprotocol/sdk";
 import type { PermissionMode } from "@letta-ai/letta-agent-sdk";
+import { realpath } from "node:fs/promises";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
 
 /**
  * ACP session modes exposed to clients (Zed renders these as a dropdown).
@@ -24,12 +33,14 @@ const SESSION_MODES = [
   {
     id: "standard",
     name: "Ask before edits",
-    description: "Request permission for file edits and shell commands",
+    description:
+      "Allow workspace reads; ask before edits, shell commands, and outside-workspace reads",
   },
   {
     id: "acceptEdits",
     name: "Accept edits",
-    description: "Auto-allow file edits; still ask for shell commands",
+    description:
+      "Allow workspace reads and file edits; ask before shell commands and outside-workspace reads",
   },
   {
     id: "unrestricted",
@@ -100,4 +111,66 @@ export function modeAutoAllows(mode: PermissionMode, toolName: string): boolean 
   if (BOOKKEEPING_TOOLS.has(toolName)) return true;
   if (mode === "acceptEdits") return EDIT_TOOLS.has(toolName);
   return false;
+}
+
+/**
+ * Editor reads match the harness's read-only tool behavior only inside the
+ * active workspace. Canonicalize both paths before comparing so `..`, sibling
+ * prefixes, and symlinks cannot turn an apparently local read into an
+ * automatic approval. New unsaved files inherit their nearest existing
+ * ancestor; malformed or otherwise unresolvable targets stay controlled.
+ */
+export async function editorReadAutoAllows(
+  mode: PermissionMode,
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  cwd: string,
+): Promise<boolean> {
+  if (toolName !== "read_editor_buffer") return false;
+  if (mode === "unrestricted") return true;
+
+  const requestedPath = toolInput.path;
+  if (typeof requestedPath !== "string" || !isAbsolute(requestedPath)) {
+    return false;
+  }
+
+  try {
+    const [workspace, target] = await Promise.all([
+      realpath(resolve(cwd)),
+      canonicalBoundaryPath(requestedPath),
+    ]);
+    const fromWorkspace = relative(workspace, target);
+    return (
+      fromWorkspace === "" ||
+      (fromWorkspace !== ".." &&
+        !fromWorkspace.startsWith(`..${sep}`) &&
+        !isAbsolute(fromWorkspace))
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve symlinks while still supporting a new unsaved editor buffer. */
+async function canonicalBoundaryPath(path: string): Promise<string> {
+  let cursor = resolve(path);
+  const missingSegments: string[] = [];
+  while (true) {
+    try {
+      const existing = await realpath(cursor);
+      return resolve(existing, ...missingSegments);
+    } catch (error) {
+      if (
+        !error ||
+        typeof error !== "object" ||
+        (error as NodeJS.ErrnoException).code !== "ENOENT"
+      ) {
+        throw error;
+      }
+      const parent = dirname(cursor);
+      if (parent === cursor) throw new Error(`Cannot resolve ${path}`);
+      missingSegments.unshift(basename(cursor));
+      cursor = parent;
+    }
+  }
 }

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentContext } from "@agentclientprotocol/sdk";
@@ -598,10 +598,15 @@ function createAgent(
 }
 
 function createContext(
-  options: { answerPermissions?: boolean; permissionDelayMs?: number } = {},
+  options: {
+    answerPermissions?: boolean;
+    permissionDelayMs?: number;
+    permissionOptionId?: "allow_once" | "allow_always" | "reject_once";
+  } = {},
 ) {
   const answerPermissions = options.answerPermissions ?? true;
   const permissionDelayMs = options.permissionDelayMs ?? 0;
+  const permissionOptionId = options.permissionOptionId ?? "allow_once";
   const updates: WireMessage[] = [];
   const permissionRequests: WireMessage[] = [];
   const permissionSignals: Array<AbortSignal | undefined> = [];
@@ -621,19 +626,20 @@ function createContext(
         await Bun.sleep(permissionDelayMs);
       }
       return {
-        outcome: { outcome: "selected" as const, optionId: "allow_once" },
+        outcome: { outcome: "selected" as const, optionId: permissionOptionId },
       };
     },
   } as unknown as AgentContext;
   return { context, updates, permissionRequests, permissionSignals };
 }
 
-async function openSession(agent: LettaAcpAgent, context: AgentContext) {
+async function openSession(
+  agent: LettaAcpAgent,
+  context: AgentContext,
+  cwd = "/tmp/letta-acp-test",
+) {
   await agent.initialize({ protocolVersion: 1, clientCapabilities: {} });
-  return agent.newSession(
-    { cwd: "/tmp/letta-acp-test", mcpServers: [] },
-    context,
-  );
+  return agent.newSession({ cwd, mcpServers: [] }, context);
 }
 
 describe("Agent SDK app-server integration", () => {
@@ -1176,6 +1182,154 @@ describe("Agent SDK app-server integration", () => {
       expect(permissionRequests).toEqual([]);
     } finally {
       agent.shutdown();
+    }
+  });
+
+  test("aligns editor-tool approvals with session modes and cwd", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context, permissionRequests } = createContext();
+    const root = await mkdtemp(join(tmpdir(), "letta-acp-editor-permissions-"));
+    const workspace = join(root, "repo");
+    const inside = join(workspace, "src", "inside.ts");
+    const outside = join(root, "outside.ts");
+    await mkdir(join(workspace, "src"), { recursive: true });
+    await writeFile(inside, "inside\n");
+    await writeFile(outside, "outside\n");
+
+    try {
+      const session = await openSession(agent, context, workspace);
+      await agent.prompt(
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "plain prompt" }],
+        },
+        context,
+      );
+
+      const insideApproval = server.nextApprovalResponse();
+      server.requestPermissionAfterPrompt({
+        requestId: "read-inside",
+        toolName: "read_editor_buffer",
+        toolCallId: "call-read-inside",
+        input: { path: inside },
+      });
+      expect(await insideApproval).toMatchObject({
+        request_id: "read-inside",
+        decision: { behavior: "allow" },
+      });
+      expect(permissionRequests).toEqual([]);
+
+      const outsideApproval = server.nextApprovalResponse();
+      server.requestPermissionAfterPrompt({
+        requestId: "read-outside",
+        toolName: "read_editor_buffer",
+        toolCallId: "call-read-outside",
+        input: { path: outside },
+      });
+      await outsideApproval;
+      expect(permissionRequests.at(-1)).toMatchObject({
+        toolCall: {
+          toolCallId: "call-read-outside",
+          kind: "read",
+          rawInput: { path: outside },
+        },
+      });
+
+      const standardWrite = server.nextApprovalResponse();
+      server.requestPermissionAfterPrompt({
+        requestId: "write-standard",
+        toolName: "write_via_editor",
+        toolCallId: "call-write-standard",
+        input: { path: inside, content: "changed\n" },
+      });
+      await standardWrite;
+      expect(permissionRequests.at(-1)).toMatchObject({
+        toolCall: {
+          toolCallId: "call-write-standard",
+          kind: "edit",
+        },
+      });
+
+      await agent.setSessionConfigOption({
+        sessionId: session.sessionId,
+        configId: "permissions",
+        value: "acceptEdits",
+      });
+      const requestCount = permissionRequests.length;
+      const acceptedWrite = server.nextApprovalResponse();
+      server.requestPermissionAfterPrompt({
+        requestId: "write-accepted",
+        toolName: "write_via_editor",
+        toolCallId: "call-write-accepted",
+        input: { path: inside, content: "accepted\n" },
+      });
+      expect(await acceptedWrite).toMatchObject({
+        request_id: "write-accepted",
+        decision: { behavior: "allow" },
+      });
+      expect(permissionRequests).toHaveLength(requestCount);
+    } finally {
+      agent.shutdown();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("scopes always-allow editor decisions to one ACP session", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context, permissionRequests } = createContext({
+      permissionOptionId: "allow_always",
+    });
+    const root = await mkdtemp(join(tmpdir(), "letta-acp-editor-always-"));
+    const firstWorkspace = join(root, "first");
+    const secondWorkspace = join(root, "second");
+    const outside = join(root, "outside.ts");
+    await mkdir(firstWorkspace, { recursive: true });
+    await mkdir(secondWorkspace, { recursive: true });
+    await writeFile(outside, "outside\n");
+
+    try {
+      const first = await openSession(agent, context, firstWorkspace);
+      await agent.prompt(
+        {
+          sessionId: first.sessionId,
+          prompt: [{ type: "text", text: "plain prompt" }],
+        },
+        context,
+      );
+      for (const requestId of ["first-read", "first-read-again"]) {
+        const approval = server.nextApprovalResponse();
+        server.requestPermissionAfterPrompt({
+          requestId,
+          toolName: "read_editor_buffer",
+          toolCallId: `call-${requestId}`,
+          input: { path: outside },
+        });
+        await approval;
+      }
+      expect(permissionRequests).toHaveLength(1);
+
+      const second = await openSession(agent, context, secondWorkspace);
+      await agent.prompt(
+        {
+          sessionId: second.sessionId,
+          prompt: [{ type: "text", text: "plain prompt" }],
+        },
+        context,
+      );
+      const secondApproval = server.nextApprovalResponse();
+      server.requestPermissionAfterPrompt({
+        requestId: "second-read",
+        toolName: "read_editor_buffer",
+        toolCallId: "call-second-read",
+        input: { path: outside },
+      });
+      await secondApproval;
+      expect(permissionRequests).toHaveLength(2);
+    } finally {
+      agent.shutdown();
+      await rm(root, { recursive: true, force: true });
     }
   });
 

--- a/test/session-modes.test.ts
+++ b/test/session-modes.test.ts
@@ -112,6 +112,10 @@ describe("editor read workspace boundary", () => {
     await writeFile(outside, "secret\n");
     await symlink(outside, join(workspace, "linked-secret.ts"));
     await symlink(sibling, join(workspace, "linked-directory"));
+    await symlink(
+      join(sibling, "missing-target.ts"),
+      join(workspace, "dangling-secret.ts"),
+    );
 
     for (const mode of ["standard", "acceptEdits"] as const) {
       for (const path of [
@@ -119,6 +123,7 @@ describe("editor read workspace boundary", () => {
         join(workspace, "..", "repo-private", "secret.ts"),
         join(workspace, "linked-secret.ts"),
         join(workspace, "linked-directory", "missing.ts"),
+        join(workspace, "dangling-secret.ts"),
       ]) {
         expect(
           await editorReadAutoAllows(

--- a/test/session-modes.test.ts
+++ b/test/session-modes.test.ts
@@ -1,8 +1,22 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  editorReadAutoAllows,
   modeAutoAllows,
   permissionModeConfigOption,
 } from "../src/session-modes.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
 
 const BOOKKEEPING_TOOLS = [
   "TaskCreate",
@@ -25,12 +39,14 @@ describe("session mode tool approvals", () => {
         {
           value: "standard",
           name: "Ask before edits",
-          description: "Request permission for file edits and shell commands",
+          description:
+            "Allow workspace reads; ask before edits, shell commands, and outside-workspace reads",
         },
         {
           value: "acceptEdits",
           name: "Accept edits",
-          description: "Auto-allow file edits; still ask for shell commands",
+          description:
+            "Allow workspace reads and file edits; ask before shell commands and outside-workspace reads",
         },
         {
           value: "unrestricted",
@@ -56,7 +72,82 @@ describe("session mode tool approvals", () => {
 
   test("keeps accept-edits and unrestricted behavior", () => {
     expect(modeAutoAllows("acceptEdits", "Edit")).toBe(true);
+    expect(modeAutoAllows("acceptEdits", "write_via_editor")).toBe(true);
     expect(modeAutoAllows("acceptEdits", "Bash")).toBe(false);
     expect(modeAutoAllows("unrestricted", "Bash")).toBe(true);
+  });
+});
+
+describe("editor read workspace boundary", () => {
+  test("auto-allows canonical files inside the session cwd", async () => {
+    const root = await mkdtemp(join(tmpdir(), "letta-acp-mode-"));
+    temporaryDirectories.push(root);
+    const workspace = join(root, "repo");
+    const source = join(workspace, "src", "index.ts");
+    await mkdir(join(workspace, "src"), { recursive: true });
+    await writeFile(source, "export {};\n");
+
+    for (const mode of ["standard", "acceptEdits"] as const) {
+      for (const path of [source, join(workspace, "src", "unsaved.ts")]) {
+        expect(
+          await editorReadAutoAllows(
+            mode,
+            "read_editor_buffer",
+            { path },
+            workspace,
+          ),
+        ).toBe(true);
+      }
+    }
+  });
+
+  test("keeps outside, sibling-prefix, and symlink escapes controlled", async () => {
+    const root = await mkdtemp(join(tmpdir(), "letta-acp-mode-"));
+    temporaryDirectories.push(root);
+    const workspace = join(root, "repo");
+    const sibling = join(root, "repo-private");
+    const outside = join(sibling, "secret.ts");
+    await mkdir(workspace, { recursive: true });
+    await mkdir(sibling, { recursive: true });
+    await writeFile(outside, "secret\n");
+    await symlink(outside, join(workspace, "linked-secret.ts"));
+    await symlink(sibling, join(workspace, "linked-directory"));
+
+    for (const mode of ["standard", "acceptEdits"] as const) {
+      for (const path of [
+        outside,
+        join(workspace, "..", "repo-private", "secret.ts"),
+        join(workspace, "linked-secret.ts"),
+        join(workspace, "linked-directory", "missing.ts"),
+      ]) {
+        expect(
+          await editorReadAutoAllows(
+            mode,
+            "read_editor_buffer",
+            { path },
+            workspace,
+          ),
+        ).toBe(false);
+      }
+    }
+  });
+
+  test("does not affect other tools and unrestricted remains unrestricted", async () => {
+    expect(
+      await editorReadAutoAllows(
+        "standard",
+        "write_via_editor",
+        { path: "/outside/file.ts" },
+        "/workspace",
+      ),
+    ).toBe(false);
+    expect(
+      await editorReadAutoAllows(
+        "unrestricted",
+        "read_editor_buffer",
+        { path: "/outside/file.ts" },
+        "/workspace",
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- auto-allow `read_editor_buffer` in `standard` and `acceptEdits` only when its canonical target stays inside the session workspace
- preserve permission prompts for outside-workspace reads and `standard`-mode editor writes
- retain automatic editor writes in `acceptEdits` and all tool calls in `unrestricted`
- keep “always allow” decisions scoped to one ACP session
- update permission descriptions to match actual behavior

## Boundary
The workspace check canonicalizes the session cwd and target before comparing them. This rejects `..` traversal, sibling-prefix confusion, file symlinks, and symlinked parent-directory escapes. New unsaved buffers are supported by canonicalizing their nearest existing ancestor.

## Validation
- [x] `bun run check` — 68 tests, typecheck, and build
- [x] `bun run test:acpx` — real ACP stdio client boundary
- [x] integration coverage for workspace read, outside read, standard write, accept-edits write, and session-scoped always-allow
- [x] negative path coverage for traversal, sibling prefixes, symlink files, and symlink directories

Closes #10

👾 Generated with [Letta Code](https://letta.com)