### PR TITLE
feat: infer the backend from the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ The adapter reaches Letta through one of four backends, selected with
 `LETTA_ACP_BACKEND` ([self-hosting docs](https://docs.letta.com/self-hosting)).
 Each subsection below shows the full `env` block for that backend.
 
+`LETTA_ACP_BACKEND` is optional: with it unset the backend follows the rest of
+the environment — `remote` when `LETTA_APP_SERVER_URL` is set, otherwise `cloud`
+when `LETTA_API_KEY` is set, otherwise `local`. The choice is logged at startup.
+Set the variable explicitly to override, which is what `cloud-oauth` requires.
+
 ### Letta Cloud (`cloud`)
 
 Agents run on Letta's hosted platform; the harness executes in a cloud

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -35,6 +35,7 @@ import {
   type SDKMessage,
   type SDKResultMessage,
 } from "@letta-ai/letta-agent-sdk";
+import { log } from "./log.js";
 import { authMethodsForClient } from "./auth.js";
 import type { LettaAcpConfig } from "./config.js";
 import {
@@ -1333,7 +1334,3 @@ export function toLettaContent(blocks: ContentBlock[]): MessageContentItem[] {
   return content;
 }
 
-function log(message: string): void {
-  // stdout carries the ACP JSON-RPC stream; all logging goes to stderr.
-  console.error(`[letta-acp] ${message}`);
-}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { log } from "./log.js";
 import type {
   LettaCodeClientOptions,
   PermissionMode,
@@ -38,10 +39,41 @@ const PERMISSION_MODES: PermissionMode[] = [
 
 const BACKENDS = ["local", "remote", "cloud", "cloud-oauth"] as const;
 
+/** Remote app-server URL, or undefined when unset or blank. */
+function remoteUrlOf(
+  env: Record<string, string | undefined>,
+): string | undefined {
+  const url = env.LETTA_APP_SERVER_URL;
+  return url && url.trim().length > 0 ? url : undefined;
+}
+
+/**
+ * Backend to use when `LETTA_ACP_BACKEND` is not set.
+ *
+ * The environment already says where the agent should live, so requiring a
+ * second variable to repeat it is a step users forget — and the failure is
+ * indirect: the adapter starts, opens a session, then dies mid-turn on a
+ * credential the chosen backend never needed.
+ *
+ * An app-server URL names one specific server, so it wins over an API key that
+ * may have been exported for unrelated tooling; the key alone means Letta
+ * Cloud; neither means everything runs here. Set `LETTA_ACP_BACKEND` to
+ * override.
+ */
+function inferBackend(env: Record<string, string | undefined>): string {
+  if (remoteUrlOf(env)) return "remote";
+  if (env.LETTA_API_KEY) return "cloud";
+  return "local";
+}
+
 export function configFromEnv(
   env: Record<string, string | undefined> = process.env,
 ): LettaAcpConfig {
-  const backend = env.LETTA_ACP_BACKEND ?? "local";
+  const explicitBackend = env.LETTA_ACP_BACKEND;
+  const backend = explicitBackend ?? inferBackend(env);
+  if (!explicitBackend) {
+    log(`backend inferred from the environment: ${backend}`);
+  }
 
   let clientOptions: LettaCodeClientOptions;
   let sessionRegistryScope = backend;
@@ -50,7 +82,7 @@ export function configFromEnv(
       clientOptions = { backend: "local" };
       break;
     case "remote": {
-      const url = env.LETTA_APP_SERVER_URL ?? "ws://127.0.0.1:4500";
+      const url = remoteUrlOf(env) ?? "ws://127.0.0.1:4500";
       clientOptions = {
         backend: "remote",
         url,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,10 @@
  * backed by a Letta agent via @letta-ai/letta-agent-sdk.
  *
  * Environment:
- *   LETTA_ACP_BACKEND          local (default) | remote | cloud | cloud-oauth
+ *   LETTA_ACP_BACKEND          local | remote | cloud | cloud-oauth. Inferred
+ *                              when unset: remote if LETTA_APP_SERVER_URL is
+ *                              set, else cloud if LETTA_API_KEY is set, else
+ *                              local.
  *   LETTA_APP_SERVER_URL       remote backend URL (default ws://127.0.0.1:4500)
  *   LETTA_APP_SERVER_TOKEN     remote backend auth token
  *   LETTA_API_KEY              cloud backend API key (not needed for cloud-oauth)

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,10 @@
+/**
+ * Adapter logging.
+ *
+ * stdout carries the ACP JSON-RPC stream, so every diagnostic goes to stderr —
+ * a stray stdout write corrupts the protocol framing and the client drops the
+ * connection.
+ */
+export function log(message: string): void {
+  console.error(`[letta-acp] ${message}`);
+}

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { configFromEnv } from "../src/config.js";
+
+/**
+ * `configFromEnv` reads `process.env` by default; every case here passes an
+ * explicit environment so the developer's own Letta credentials cannot decide
+ * the result.
+ */
+describe("backend inference", () => {
+  test("an API key alone selects cloud", () => {
+    const config = configFromEnv({ LETTA_API_KEY: "sk-let-test" });
+    expect(config.clientOptions).toEqual({
+      backend: "cloud",
+      apiKey: "sk-let-test",
+    });
+  });
+
+  test("an empty environment stays local", () => {
+    expect(configFromEnv({}).clientOptions).toEqual({ backend: "local" });
+  });
+
+  test("an app-server URL selects remote and is used verbatim", () => {
+    const config = configFromEnv({
+      LETTA_APP_SERVER_URL: "ws://box:4500",
+      LETTA_APP_SERVER_TOKEN: "tok",
+    });
+    expect(config.clientOptions).toEqual({
+      backend: "remote",
+      url: "ws://box:4500",
+      authToken: "tok",
+    });
+  });
+
+  test("an app-server URL wins over an API key", () => {
+    // A URL names one specific server; an API key is often exported for
+    // unrelated tooling, so it must not silently redirect to Letta Cloud.
+    const config = configFromEnv({
+      LETTA_APP_SERVER_URL: "ws://box:4500",
+      LETTA_API_KEY: "sk-let-test",
+    });
+    expect(config.clientOptions).toMatchObject({ backend: "remote" });
+  });
+
+  test("a blank URL does not select remote", () => {
+    expect(
+      configFromEnv({ LETTA_APP_SERVER_URL: "  ", LETTA_API_KEY: "sk-let-test" })
+        .clientOptions,
+    ).toMatchObject({ backend: "cloud" });
+    expect(
+      configFromEnv({ LETTA_APP_SERVER_URL: "" }).clientOptions,
+    ).toEqual({ backend: "local" });
+  });
+
+  test("an explicit backend overrides inference", () => {
+    // Reaching Letta Cloud through `letta login` rather than a key.
+    const config = configFromEnv({
+      LETTA_ACP_BACKEND: "cloud-oauth",
+      LETTA_API_KEY: "sk-let-test",
+      LETTA_APP_SERVER_URL: "ws://box:4500",
+    });
+    expect(config.clientOptions).toMatchObject({ backend: "local" });
+    expect(config.sessionRegistryScope).toBe("cloud");
+  });
+
+  test("an explicit cloud backend still requires a key", () => {
+    expect(() => configFromEnv({ LETTA_ACP_BACKEND: "cloud" })).toThrow(
+      /requires LETTA_API_KEY/,
+    );
+  });
+
+  test("an unknown backend is rejected", () => {
+    expect(() => configFromEnv({ LETTA_ACP_BACKEND: "nope" })).toThrow(
+      /Unknown LETTA_ACP_BACKEND/,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`LETTA_ACP_BACKEND` had to restate what the rest of the environment already said. Setting `LETTA_API_KEY` alone left the adapter on `local`, and the failure was indirect — it started fine, opened a session, listed a full model catalog, and only died mid-turn on a credential the intended backend never needed:

```
[letta-acp] stream error: OpenAI API error (401): Incorrect API key provided: sk-proj-****
```

The local backend had fallen back to a stale `OPENAI_API_KEY` inherited from the shell. Under a harness like [Buzz](https://github.com/block/buzz) this surfaces as a generic "The agent's harness reported an internal error" with nothing pointing at the real cause: a second variable was missing.

## Change

With `LETTA_ACP_BACKEND` unset, the backend follows the environment:

| Environment | Backend |
|---|---|
| `LETTA_APP_SERVER_URL` set | `remote` |
| `LETTA_API_KEY` set | `cloud` |
| neither | `local` |

The choice is logged at startup (`backend inferred from the environment: cloud`) so it is never a silent guess, and setting `LETTA_ACP_BACKEND` explicitly still wins — which `cloud-oauth` requires, since it is reached through `letta login` rather than through anything else in the environment.

No new environment variables: this reads the ones the adapter already documents.

Two deliberate details:

- **An app-server URL wins over an API key.** It names one specific server, whereas `LETTA_API_KEY` is often exported for unrelated tooling; silently redirecting to Letta Cloud would make `LETTA_APP_SERVER_URL` look inert.
- **Blank values do not count as set**, so an empty var in a `.env` cannot force a backend.

The `log` helper moves out of `agent.ts` into its own module so `config.ts` can report the inference without an import cycle.

## Verification

`bun run check` — 77 pass / 0 fail (8 new), typecheck and build clean.

End-to-end against real backends, driving `session/new` over stdio ACP:

- `LETTA_API_KEY` only, **with a deliberately invalid `OPENAI_API_KEY` also exported** → cloud, 797-model catalog
- empty environment → local, 282-model catalog
- `LETTA_APP_SERVER_URL` + `LETTA_API_KEY` → remote

The invalid-OpenAI-key case is the regression that motivated this: before the change it reproduced the 401 above.