### PR TITLE
fix: never run tools in a Letta cloud sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,29 +95,33 @@ The adapter reaches Letta through one of four backends, selected with
 Each subsection below shows the full `env` block for that backend.
 
 `LETTA_ACP_BACKEND` is optional: with it unset the backend follows the rest of
-the environment — `remote` when `LETTA_APP_SERVER_URL` is set, otherwise `cloud`
-when `LETTA_API_KEY` is set, otherwise `local`. The choice is logged at startup.
-Set the variable explicitly to override, which is what `cloud-oauth` requires.
+the environment — `remote` when `LETTA_APP_SERVER_URL` is set, otherwise
+`cloud` when `LETTA_API_KEY` is set, otherwise `local`. The choice is logged at
+startup. Set the variable explicitly to override.
 
-### Letta Cloud (`cloud`)
+**Tools always execute on your machine** (except `remote`, where they execute on
+the app server you pointed at). Letta also offers a sandboxed cloud runtime, in
+which tool calls run in a Letta-managed container; this adapter does not expose
+it. An ACP client hands the agent a working directory, filesystem tools, and
+terminals that exist only where the client runs, so an agent that cannot reach
+them is not useful over ACP.
 
-Agents run on Letta's hosted platform; the harness executes in a cloud
-sandbox. Get an API key at
+### Letta Cloud (`cloud`, also spelled `cloud-oauth`)
+
+Agents and their memory live on Letta's hosted platform, with cloud-side model
+access — no provider key of your own. Tools execute here. Authenticate either
+with an API key from
 [platform.letta.com/api-keys](https://platform.letta.com/api-keys):
 
 ```json
 "env": {
-  "LETTA_ACP_BACKEND": "cloud",
   "LETTA_API_KEY": "sk-let-...",
   "LETTA_AGENT_ID": "agent-..."
 }
 ```
 
-### Letta Cloud via OAuth (`cloud-oauth`)
-
-Same cloud agents as `cloud`, but authenticated with your existing
-`letta login` session instead of an API key — so no long-lived secret has to
-be pasted into your editor's settings file.
+…or with your existing `letta login` session, so no long-lived secret has to be
+pasted into your editor's settings file.
 
 ```json
 "env": {
@@ -136,9 +140,8 @@ automatically as they expire, falling back to `LETTA_API_KEY` if one is set.
 Mechanically this is the `local` backend with the harness pointed at Letta
 Cloud (`harnessBackend: "api"`): the SDK spawns a loopback app-server on your
 machine, the agent and its memory live in Cloud (real `agent-*` ids, cloud-side
-models), and — unlike `cloud` — built-in tools such as `Read` and `Bash`
-execute against **your** filesystem rather than a cloud sandbox. For editor use
-that's usually what you want.
+models), and built-in tools such as `Read` and `Bash` execute against **your**
+filesystem.
 
 ### Local runtime (`local`, default)
 
@@ -185,9 +188,9 @@ non-loopback deployments enable auth
 | `LETTA_ACP_MODEL` | model override for sessions, as a `provider/model` handle (e.g. `anthropic/claude-fable-5`, `openai/gpt-4.1`) — run `/model` in a thread to list valid handles |
 | `LETTA_ACP_PERMISSION_MODE` | initial session mode: `standard` (default), `acceptEdits`, `unrestricted` — switchable live via `session/set_mode` (Zed's mode dropdown) |
 
-Note on tool execution: with `remote` and `cloud`, built-in tools (Read, Bash,
-…) run where the harness runs — the server/sandbox filesystem, not your
-machine. With `local` and `cloud-oauth` they run on your machine. The editor fs tools (`read_editor_buffer`, `write_via_editor`) always
+Note on tool execution: with `remote`, built-in tools (Read, Bash, …) run on
+the app server, not your machine. With `local` and `cloud` they run on your
+machine. The editor fs tools (`read_editor_buffer`, `write_via_editor`) always
 operate on the editor's files regardless of backend, since they execute in the
 adapter and delegate to the ACP client.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,9 +56,10 @@ function remoteUrlOf(
  * credential the chosen backend never needed.
  *
  * An app-server URL names one specific server, so it wins over an API key that
- * may have been exported for unrelated tooling; the key alone means Letta
- * Cloud; neither means everything runs here. Set `LETTA_ACP_BACKEND` to
- * override.
+ * may have been exported for unrelated tooling; neither means everything runs
+ * here. Set `LETTA_ACP_BACKEND` to override.
+ *
+ * An API key means the agent lives on Letta Cloud; tools still execute here.
  */
 function inferBackend(env: Record<string, string | undefined>): string {
   if (remoteUrlOf(env)) return "remote";
@@ -91,25 +92,23 @@ export function configFromEnv(
       sessionRegistryScope = `remote:${url}`;
       break;
     }
-    case "cloud": {
-      const apiKey = env.LETTA_API_KEY;
-      if (!apiKey) {
-        throw new Error(
-          "LETTA_ACP_BACKEND=cloud requires LETTA_API_KEY. " +
-            'To use your existing `letta login` session instead, set LETTA_ACP_BACKEND="cloud-oauth".',
-        );
-      }
-      clientOptions = { backend: "cloud", apiKey };
-      break;
-    }
+    // `cloud` and `cloud-oauth` are the same backend: the agent lives on Letta
+    // Cloud and tools execute here.
+    //
+    // The SDK also offers a sandboxed cloud mode, where tool calls run in a
+    // Letta-managed container. This adapter deliberately does not expose it. An
+    // ACP client hands the agent a `cwd`, filesystem tools, and terminals that
+    // exist only on the client's machine, so an agent that cannot reach them is
+    // broken in a way that surfaces late and confusingly: sessions open, model
+    // catalogs list, and the agent then reports missing files and missing CLIs
+    // for a project it was never able to see.
+    //
+    // Credentials resolve the way the letta-code CLI resolves them — OS
+    // keychain tokens from `letta login`, refreshed automatically, falling back
+    // to LETTA_API_KEY when present — so either form of auth works here.
+    case "cloud":
     case "cloud-oauth":
       sessionRegistryScope = "cloud";
-      // Cloud agents authenticated through the letta-code harness rather than
-      // an explicit API key: the SDK spawns a local app-server pointed at
-      // Letta Cloud, and that harness resolves credentials the same way the
-      // CLI does (OS keychain tokens from `letta login`, with automatic
-      // refresh, falling back to LETTA_API_KEY when present). Tools still
-      // execute on this machine.
       clientOptions = {
         backend: "local",
         appServer: { harnessBackend: "api" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,14 @@
  * backed by a Letta agent via @letta-ai/letta-agent-sdk.
  *
  * Environment:
- *   LETTA_ACP_BACKEND          local | remote | cloud | cloud-oauth. Inferred
+ *   LETTA_ACP_BACKEND          local | remote | cloud (= cloud-oauth). Inferred
  *                              when unset: remote if LETTA_APP_SERVER_URL is
  *                              set, else cloud if LETTA_API_KEY is set, else
- *                              local.
+ *                              local. Tools always execute locally, except on
+ *                              remote.
  *   LETTA_APP_SERVER_URL       remote backend URL (default ws://127.0.0.1:4500)
  *   LETTA_APP_SERVER_TOKEN     remote backend auth token
- *   LETTA_API_KEY              cloud backend API key (not needed for cloud-oauth)
+ *   LETTA_API_KEY              Letta Cloud API key (cloud and cloud-oauth)
  *   LETTA_AGENT_ID             reuse an existing agent (recommended)
  *   LETTA_ACP_MODEL            model override for sessions
  *   LETTA_ACP_PERMISSION_MODE  standard (default) | acceptEdits | unrestricted

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -7,12 +7,36 @@ import { configFromEnv } from "../src/config.js";
  * the result.
  */
 describe("backend inference", () => {
-  test("an API key alone selects cloud", () => {
+  test("an API key alone selects cloud storage with local execution", () => {
+    // `cloud-oauth` is a local app-server pointed at Letta Cloud: the agent
+    // lives in the cloud, tools run on this machine. Plain `cloud` would move
+    // execution into Letta's sandbox, away from the ACP client's files.
     const config = configFromEnv({ LETTA_API_KEY: "sk-let-test" });
     expect(config.clientOptions).toEqual({
-      backend: "cloud",
-      apiKey: "sk-let-test",
+      backend: "local",
+      appServer: { harnessBackend: "api" },
     });
+    expect(config.sessionRegistryScope).toBe("cloud");
+  });
+
+  test("an explicit cloud backend also executes locally", () => {
+    // The SDK's sandboxed cloud mode is deliberately not reachable: an ACP
+    // client's cwd, files, and terminals exist only on this machine.
+    const config = configFromEnv({
+      LETTA_ACP_BACKEND: "cloud",
+      LETTA_API_KEY: "sk-let-test",
+    });
+    expect(config.clientOptions).toEqual({
+      backend: "local",
+      appServer: { harnessBackend: "api" },
+    });
+    expect(config.sessionRegistryScope).toBe("cloud");
+  });
+
+  test("cloud and cloud-oauth are the same backend", () => {
+    expect(configFromEnv({ LETTA_ACP_BACKEND: "cloud" })).toEqual(
+      configFromEnv({ LETTA_ACP_BACKEND: "cloud-oauth" }),
+    );
   });
 
   test("an empty environment stays local", () => {
@@ -42,10 +66,11 @@ describe("backend inference", () => {
   });
 
   test("a blank URL does not select remote", () => {
+    // Falls through to the key, i.e. cloud storage with local execution.
     expect(
       configFromEnv({ LETTA_APP_SERVER_URL: "  ", LETTA_API_KEY: "sk-let-test" })
-        .clientOptions,
-    ).toMatchObject({ backend: "cloud" });
+        .sessionRegistryScope,
+    ).toBe("cloud");
     expect(
       configFromEnv({ LETTA_APP_SERVER_URL: "" }).clientOptions,
     ).toEqual({ backend: "local" });
@@ -62,10 +87,9 @@ describe("backend inference", () => {
     expect(config.sessionRegistryScope).toBe("cloud");
   });
 
-  test("an explicit cloud backend still requires a key", () => {
-    expect(() => configFromEnv({ LETTA_ACP_BACKEND: "cloud" })).toThrow(
-      /requires LETTA_API_KEY/,
-    );
+  test("cloud works without a key, via letta login", () => {
+    // Credentials resolve like the CLI's: keychain token or LETTA_API_KEY.
+    expect(() => configFromEnv({ LETTA_ACP_BACKEND: "cloud" })).not.toThrow();
   });
 
   test("an unknown backend is rejected", () => {


### PR DESCRIPTION
## Problem

ACP is a local protocol. The client hands the agent a working directory, filesystem tools, and terminals that exist only where the client runs — so an agent whose tools execute in a Letta-managed container cannot honor any of it.

Nothing fails at connect time, which is what makes it costly: the session opens, the model catalog lists, slash commands advertise, and only mid-turn does the agent start reporting that the project's files and the client's CLI do not exist. Running an agent under [Buzz](https://github.com/block/buzz) on the sandboxed backend, it answered:

> The buzz CLI is not found. Let me check if it's installed somewhere else… The buzz CLI doesn't seem to be installed.

It was installed. The agent was simply not on this machine.

`cloud` and `cloud-oauth` were two spellings of "the agent lives on Letta Cloud" that differed in **where tools run** — `cloud` sandboxed, `cloud-oauth` local — and nothing in the names said so. Worse, the inference added in #44 mapped `LETTA_API_KEY` to `cloud`: the one backend an ACP client can never use.

## Change

Collapse the two into one backend. `cloud` and `cloud-oauth` both spawn a loopback app-server pointed at Letta Cloud: agent and memory in Cloud, with cloud-side model access, and **tools execute here**.

- The SDK's sandboxed cloud runtime is no longer reachable from this adapter.
- Credentials resolve as the CLI resolves them — keychain token from `letta login`, else `LETTA_API_KEY` — so `cloud` no longer requires a key, and `cloud-oauth` stays accepted as an alias.
- `LETTA_API_KEY` now infers this backend, correcting #44.

Tool execution by backend is now uniform: **local**, except `remote`, where tools run on the app server you explicitly pointed at.

## Verification

`bun run check` — 79 pass / 0 fail, typecheck and build clean.

Tested against real Letta Cloud by asking the agent to run `cat marker.txt ; hostname` in a `cwd` containing a file that exists only on this machine.

Before:

```
cat: marker.txt: No such file or directory
20ec1915-bda0-4000-8e09-c7dd412d3b6c        <- container id
`marker.txt` doesn't exist in the current directory (`/root`)
```

After, both with `LETTA_ACP_BACKEND=cloud` and with it unset (inferred from `LETTA_API_KEY`):

```
MARKER-LOCAL-EXEC-4417-QUARK
MacBook-Pro-101.local
```