### PR TITLE
fix: drain cancelled turns before replacement prompts

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -799,10 +799,13 @@ export class LettaAcpAgent {
       }
       if (message.type === "loop_status") {
         activeRunIds = message.activeRunIds;
-        // An abort that lands before the run produces output never gets a
-        // terminal result from the SDK — the return to WAITING_ON_INPUT is
-        // the only end-of-turn signal, in "turn" mode too.
+        // An abort after real turn activity makes the SDK enqueue this idle
+        // status followed by the cancelled turn's synthesized result. Drain
+        // that result before returning so the next prompt cannot consume it
+        // as its own terminal event. An abort before any activity has no
+        // result, so the idle status remains its only completion signal.
         if (message.status === "WAITING_ON_INPUT" && state.cancelled) {
+          if (sawActivity) continue;
           return { kind: "idle" };
         }
         if (mode === "recovery") {

--- a/test/agent-integration.test.ts
+++ b/test/agent-integration.test.ts
@@ -33,6 +33,8 @@ class FakeAppServer {
   private activeCommand: string | null = null;
   private approvalWaiters: Array<(payload: WireMessage) => void> = [];
   private commandWaiters: Array<() => void> = [];
+  private cancelablePromptWaiters: Array<() => void> = [];
+  private cancelablePromptActive = false;
 
   socketConstructor(): LettaCodeSocketConstructor {
     const server = this;
@@ -100,6 +102,13 @@ class FakeAppServer {
   nextCommand(): Promise<void> {
     return new Promise((resolve) => {
       this.commandWaiters.push(resolve);
+    });
+  }
+
+  /** Resolves after a prompt has produced activity but before it completes. */
+  nextCancelablePrompt(): Promise<void> {
+    return new Promise((resolve) => {
+      this.cancelablePromptWaiters.push(resolve);
     });
   }
 
@@ -273,7 +282,7 @@ class FakeAppServer {
           ),
           success: true,
         });
-        if (this.activeCommand) {
+        if (this.activeCommand || this.cancelablePromptActive) {
           socket.push({
             type: "update_loop_status",
             runtime: this.activeRuntime,
@@ -282,6 +291,7 @@ class FakeAppServer {
               active_run_ids: [],
             },
           });
+          this.cancelablePromptActive = false;
         }
         return;
       default:
@@ -336,6 +346,38 @@ class FakeAppServer {
     }
 
     const promptText = JSON.stringify(payload.messages);
+    if (promptText.includes("cancel active prompt")) {
+      this.cancelablePromptActive = true;
+      for (const waiter of this.cancelablePromptWaiters.splice(0)) waiter();
+      this.pushDelta(socket, runtime, {
+        message_type: "tool_call_message",
+        run_id: "run-cancelled",
+        tool_calls: [
+          {
+            id: "call-cancelled-agent",
+            name: "Agent",
+            arguments: JSON.stringify({
+              description: "Inspect test coverage",
+              prompt: "Review the repository tests",
+            }),
+          },
+        ],
+      });
+      return;
+    }
+    if (promptText.includes("replacement after cancel")) {
+      this.pushDelta(socket, runtime, {
+        message_type: "assistant_message",
+        run_id: "run-replacement",
+        content: "REPLACEMENT_OK",
+      });
+      this.pushDelta(socket, runtime, {
+        message_type: "stop_reason",
+        run_id: "run-replacement",
+        stop_reason: "end_turn",
+      });
+      return;
+    }
     if (promptText.includes("fragmented prompt")) {
       this.streamFragmentedToolCall(socket, runtime);
       return;
@@ -1635,6 +1677,44 @@ describe("Agent SDK app-server integration", () => {
       expect(updates).toContainEqual({
         sessionUpdate: "agent_message_chunk",
         content: { type: "text", text: "COMMAND_APPROVAL_OK" },
+      });
+    } finally {
+      agent.shutdown();
+    }
+  });
+
+  test("drains a cancelled turn before starting its replacement", async () => {
+    const server = new FakeAppServer();
+    const agent = createAgent(server);
+    const { context, updates } = createContext();
+
+    try {
+      const session = await openSession(agent, context);
+      const started = server.nextCancelablePrompt();
+      const first = agent.prompt(
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "cancel active prompt" }],
+        },
+        context,
+      );
+      await started;
+      await agent.cancel({ sessionId: session.sessionId });
+      expect(await first).toEqual({ stopReason: "cancelled" });
+
+      const replacementUpdateStart = updates.length;
+      const replacement = await agent.prompt(
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "replacement after cancel" }],
+        },
+        context,
+      );
+
+      expect(replacement).toEqual({ stopReason: "end_turn" });
+      expect(updates.slice(replacementUpdateStart)).toContainEqual({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "REPLACEMENT_OK" },
       });
     } finally {
       agent.shutdown();


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Problem

When a user submits another Zed prompt during an active turn, Zed first sends `session/cancel`, waits for the canceled prompt response, and then sends the replacement prompt. The adapter returned from the canceled stream on `WAITING_ON_INPUT` while the Agent SDK had queued that turn’s synthesized terminal result immediately behind it. The replacement prompt then consumed the stale result and appeared to finish immediately, while its real response continued without an ACP stream owner.

The user message persisted, but Zed showed neither ongoing work nor the eventual answer.

## Change

After substantive turn activity, keep draining a canceled stream through its SDK terminal result before returning the canceled ACP response. Cancellation before any activity still ends on the idle status because the SDK produces no result in that case.

## Proof

- a live Zed stdio trace reproduced `cancel A → settle A → send B`; B returned in 3 ms while its server-side answer was never forwarded to Zed
- the deterministic Agent SDK integration regression fails on current main because B receives `{ stopReason: "cancelled" }`
- the same regression passes with B receiving its own streamed answer and `{ stopReason: "end_turn" }`
- `bun run check` — 70 tests, typecheck, and build pass

## Limits

This does not change Zed’s cancel-before-reprompt behavior. It makes the adapter fully retire the canceled turn before accepting the replacement stream.

Closes #11

👾 Generated with [Letta Code](https://letta.com)