### PR TITLE
fix: clean up ACP child processes on termination

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
       "name": "acp",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",
-        "@letta-ai/letta-agent-sdk": "^0.5.8",
-        "@letta-ai/letta-code": "0.29.13",
+        "@letta-ai/letta-agent-sdk": "^0.6.2",
+        "@letta-ai/letta-code": "0.30.5",
       },
       "devDependencies": {
         "@types/bun": "^1.3.0",
@@ -186,11 +186,11 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@letta-ai/letta-agent-sdk": ["@letta-ai/letta-agent-sdk@0.5.8", "", { "dependencies": { "@letta-ai/letta-client": "^1.12.1", "@letta-ai/letta-code": "0.29.13" } }, "sha512-XioYIxrmHpxRiSi17CTF4Y028hcngPe/JtfZKC+P2tGtzSCMfbB3xf66UKC5dXhOeifplnzpEulwYg7sCZb2yQ=="],
+    "@letta-ai/letta-agent-sdk": ["@letta-ai/letta-agent-sdk@0.6.2", "", { "dependencies": { "@letta-ai/letta-client": "^1.12.1", "@letta-ai/letta-code": "0.30.5" } }, "sha512-BWYgvN9bMU1CFe+JbXLaw5b3QkYF5Guhp+F9Jwf+x/WoE/Nk5PD6l5nxE6cYo3Gu/03IJiGR6msn/ZCTlvEmig=="],
 
     "@letta-ai/letta-client": ["@letta-ai/letta-client@1.12.1", "", {}, "sha512-rYjXMXpkfssj7VBBX3qCp6mdpNRv6YPNrliYsjkhWoQDqGg3J9bsgIQ28ZhQTddabYxRUIwcdzuaizFx8pvZ7A=="],
 
-    "@letta-ai/letta-code": ["@letta-ai/letta-code@0.29.13", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.1", "@letta-ai/letta-client": "^1.10.2", "@letta-ai/trajectory": "0.2.0", "@modelcontextprotocol/sdk": "1.30.0", "@pierre/diffs": "1.2.2", "@scarf/scarf": "^1.4.0", "cron-parser": "^5.6.1", "glob": "^13.0.0", "ink-link": "^5.0.0", "node-pty": "^1.1.0", "open": "^10.2.0", "react": "18.2.0", "sharp": "^0.34.5", "shiki": "^4.0.2", "strip-ansi": "^7.2.0", "ws": "^8.19.0" }, "optionalDependencies": { "@vscode/ripgrep": "^1.17.0" }, "bin": { "letta": "letta.js" } }, "sha512-mX+V/86KVBvbkONKReKA1TwAWzhiRveiplyzCM3bB6qv3zlXIWz9B1t/jBpr+jge3Ddxx+jTkYjGC7YHlOGi6A=="],
+    "@letta-ai/letta-code": ["@letta-ai/letta-code@0.30.5", "", { "dependencies": { "@earendil-works/pi-ai": "^0.82.1", "@letta-ai/letta-client": "^1.10.2", "@letta-ai/trajectory": "0.2.0", "@modelcontextprotocol/sdk": "1.30.0", "@pierre/diffs": "1.2.2", "@scarf/scarf": "^1.4.0", "cron-parser": "^5.6.1", "cross-spawn": "^7.0.6", "glob": "^13.0.0", "ink-link": "^5.0.0", "node-pty": "^1.1.0", "open": "^10.2.0", "react": "18.2.0", "sharp": "^0.34.5", "shiki": "^4.0.2", "strip-ansi": "^7.2.0", "ws": "^8.19.0" }, "optionalDependencies": { "@vscode/ripgrep": "^1.17.0" }, "bin": { "letta": "letta.js" } }, "sha512-aDwiMSaP65RK/v/kX6EkzeC3N0O5KQ1wMIUewXiQC+IqP5AU4adnXWTQl7vXMpDhKzTzFNzAZWADIQ+l+TENGw=="],
 
     "@letta-ai/trajectory": ["@letta-ai/trajectory@0.2.0", "", {}, "sha512-biCyT0z8nh4Q8kIqBrPgmzoalacPmosmCpvEjdN9ILpL85+T75b8ahcN9MHPHQUVRj/J7UyQuRahJ4/JdrpCcA=="],
 

--- a/package.json
+++ b/package.json
@@ -47,9 +47,12 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.3.0",
-    "@letta-ai/letta-agent-sdk": "^0.5.8",
-    "@letta-ai/letta-code": "0.29.13"
+    "@letta-ai/letta-agent-sdk": "^0.6.2",
+    "@letta-ai/letta-code": "0.30.5"
   },
+  "trustedDependencies": [
+    "@letta-ai/letta-code"
+  ],
   "engines": {
     "node": ">=22.19.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,21 @@ const connection = await acp
   )
   .connect(stream);
 
+let shuttingDown = false;
+const shutdown = () => {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  connection.close();
+  agent.shutdown();
+};
+
+// Zed can terminate an ACP server without first closing stdio. Close every SDK
+// session while the process can still signal its app-server and MCP children.
+process.once("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);
+process.once("exit", shutdown);
+
 await connection.closed;
 // Session close begins MCP subprocess shutdown. Do not force-exit here: the
 // child process handles keep Node/Bun alive until that cleanup completes.
-agent.shutdown();
+shutdown();

--- a/test/acpx-client.test.ts
+++ b/test/acpx-client.test.ts
@@ -210,7 +210,9 @@ async function runAcpx(
   return { stdout, stderr, home, appServerUrl, cwd };
 }
 
-async function verifyMcpShutdownOnClientDisconnect(): Promise<void> {
+async function verifyMcpShutdown(
+  trigger: "stdin-close" | "SIGTERM",
+): Promise<void> {
   const home = mkdtempSync(join(tmpdir(), "letta-acp-mcp-shutdown-"));
   tempDirs.push(home);
   const marker = join(home, "shutdown-marker");
@@ -286,11 +288,15 @@ async function verifyMcpShutdownOnClientDisconnect(): Promise<void> {
     expect(sessionOpened).toBe(true);
     expect(existsSync(pidFile)).toBe(true);
 
-    child.stdin.end();
+    if (trigger === "SIGTERM") {
+      child.kill("SIGTERM");
+    } else {
+      child.stdin.end();
+    }
     const exitCode = await Promise.race([
       child.exited,
       Bun.sleep(8_000).then(() => {
-        throw new Error("adapter did not exit after ACP stdin closed");
+        throw new Error(`adapter did not exit after ${trigger}`);
       }),
     ]);
     expect(exitCode).toBe(0);
@@ -342,7 +348,11 @@ describe("acpx client compatibility", () => {
   }, 10_000);
 
   test("waits for MCP subprocess cleanup after the client disconnects", async () => {
-    await verifyMcpShutdownOnClientDisconnect();
+    await verifyMcpShutdown("stdin-close");
+  }, 12_000);
+
+  test("closes child processes when the ACP server receives SIGTERM", async () => {
+    await verifyMcpShutdown("SIGTERM");
   }, 12_000);
 
   test("emits a complete tool lifecycle as ACP notifications", async () => {

--- a/test/acpx-client.test.ts
+++ b/test/acpx-client.test.ts
@@ -299,8 +299,8 @@ async function verifyMcpShutdown(
         throw new Error(`adapter did not exit after ${trigger}`);
       }),
     ]);
-    expect(exitCode).toBe(0);
     expect(existsSync(marker)).toBe(true);
+    expect(exitCode).toBe(0);
   } finally {
     if (child.exitCode === null) child.kill();
     if (existsSync(pidFile) && !existsSync(marker)) {
@@ -313,6 +313,115 @@ async function verifyMcpShutdown(
         }
       }
     }
+  }
+}
+
+async function verifyAppServerShutdownOnSignal(): Promise<void> {
+  const home = mkdtempSync(join(tmpdir(), "letta-acp-app-server-shutdown-"));
+  tempDirs.push(home);
+  const marker = join(home, "shutdown-marker");
+  const pidFile = join(home, "app-server-pid");
+  const appServerUrl = startFakeAppServer();
+  const agentPath = join(import.meta.dir, "..", "src", "index.ts");
+  const cliPath = join(
+    import.meta.dir,
+    "fixtures",
+    "stubborn-app-server.ts",
+  );
+  const child = Bun.spawn([process.execPath, agentPath], {
+    cwd: join(import.meta.dir, ".."),
+    env: {
+      ...process.env,
+      HOME: home,
+      LETTA_ACP_BACKEND: "local",
+      LETTA_AGENT_ID: TEST_RUNTIME.agent_id,
+      LETTA_CLI_PATH: cliPath,
+      FAKE_APP_SERVER_URL: appServerUrl,
+      APP_SERVER_SHUTDOWN_MARKER: marker,
+      APP_SERVER_PID_FILE: pidFile,
+    },
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const send = (message: WireMessage) => {
+    child.stdin.write(`${JSON.stringify(message)}\n`);
+    child.stdin.flush();
+  };
+  send({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: { protocolVersion: 1, clientCapabilities: {} },
+  });
+  send({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "session/new",
+    params: { cwd: join(import.meta.dir, ".."), mcpServers: [] },
+  });
+
+  let buffer = "";
+  let sessionOpened = false;
+  const decoder = new TextDecoder();
+  let appServerPid: number | null = null;
+  try {
+    for await (const chunk of child.stdout) {
+      buffer += decoder.decode(chunk, { stream: true });
+      let newline = buffer.indexOf("\n");
+      while (newline !== -1) {
+        const line = buffer.slice(0, newline).trim();
+        buffer = buffer.slice(newline + 1);
+        if (line) {
+          const message = JSON.parse(line) as WireMessage;
+          if (message.id === 2 && message.result) {
+            sessionOpened = true;
+            break;
+          }
+        }
+        newline = buffer.indexOf("\n");
+      }
+      if (sessionOpened) break;
+    }
+    expect(sessionOpened).toBe(true);
+    expect(existsSync(pidFile)).toBe(true);
+    appServerPid = Number(readFileSync(pidFile, "utf8"));
+    expect(Number.isInteger(appServerPid)).toBe(true);
+
+    child.kill("SIGTERM");
+    const exitCode = await Promise.race([
+      child.exited,
+      Bun.sleep(8_000).then(() => {
+        throw new Error("adapter did not exit after SIGTERM");
+      }),
+    ]);
+    expect(existsSync(marker)).toBe(true);
+    expect(exitCode).toBe(0);
+
+    for (let attempt = 0; attempt < 50 && processExists(appServerPid); attempt++) {
+      await Bun.sleep(20);
+    }
+    expect(processExists(appServerPid)).toBe(false);
+  } finally {
+    if (child.exitCode === null) child.kill();
+    if (appServerPid !== null && processExists(appServerPid)) {
+      try {
+        process.kill(appServerPid, "SIGTERM");
+      } catch {
+        // The fixture may already have exited while cleanup raced the test.
+      }
+    }
+  }
+}
+
+function processExists(pid: number | null): boolean {
+  if (pid === null || !Number.isInteger(pid)) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -351,8 +460,12 @@ describe("acpx client compatibility", () => {
     await verifyMcpShutdown("stdin-close");
   }, 12_000);
 
-  test("closes child processes when the ACP server receives SIGTERM", async () => {
+  test("closes MCP children when the ACP server receives SIGTERM", async () => {
     await verifyMcpShutdown("SIGTERM");
+  }, 12_000);
+
+  test("closes SDK-owned app servers when the ACP server receives SIGTERM", async () => {
+    await verifyAppServerShutdownOnSignal();
   }, 12_000);
 
   test("emits a complete tool lifecycle as ACP notifications", async () => {

--- a/test/fixtures/stubborn-app-server.ts
+++ b/test/fixtures/stubborn-app-server.ts
@@ -1,0 +1,16 @@
+import { writeFileSync } from "node:fs";
+
+const url = process.env.FAKE_APP_SERVER_URL;
+const marker = process.env.APP_SERVER_SHUTDOWN_MARKER;
+const pidFile = process.env.APP_SERVER_PID_FILE;
+
+if (!url) throw new Error("FAKE_APP_SERVER_URL is required");
+if (pidFile) writeFileSync(pidFile, String(process.pid));
+
+process.stdout.write(`Listening on ${url}\n`);
+setInterval(() => {}, 1_000);
+
+process.on("SIGTERM", () => {
+  if (marker) writeFileSync(marker, "terminated");
+  process.exit(0);
+});


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary
- close the ACP connection and active SDK sessions on SIGINT, SIGTERM, and process exit
- prevent Zed termination from leaving SDK-owned app-server or MCP children behind
- update to Letta Agent SDK 0.6.2 and Letta Code 0.30.5, with trusted runtime installation

## Validation
- [x] `bun run check` — 77 tests, typecheck, and build pass
- [x] exact app-server regression fails on `origin/main` because the child receives no SIGTERM, then passes on this branch
- [x] real `acpx` → adapter → Cloud OAuth model turn returned `ACP_OAUTH_OK`
- [ ] explicit-key live Cloud CI is blocked because the current repository credential receives HTTP 403; the same agent-creation failure reproduces on `origin/main` and this branch

👾 Generated with [Letta Code](https://letta.com)